### PR TITLE
fix: updated gui inclusion for ipython 0.11

### DIFF
--- a/bin/pysurfer
+++ b/bin/pysurfer
@@ -17,7 +17,7 @@ from surfer._commandline import parser
 if len(sys.argv) < 4:
     parser.parse_args(["--help"])
 else:
-    parser.parse_args()
+    args = parser.parse_args()
 
 # Make sure this is going to work before we have to
 # boot up mlab/IPython
@@ -34,8 +34,8 @@ import IPython
 if IPython.__version__ < '0.11':
     flag = '-wthread'
 else:
-    flag = '--gui=wx'
-os.system('ipython %s'%flag +
+    flag = '--gui=%s'%args.gui
+os.system('ipython %s '%flag +
                    load_file +
                    ' "%s"'
                    % ' '.join(sys.argv[1:]))

--- a/surfer/_commandline.py
+++ b/surfer/_commandline.py
@@ -66,3 +66,5 @@ parser.add_argument("-cortex", metavar="COLOR",
                     help="colormap for binary cortex curvature")
 parser.add_argument("-title",
                     help="title to use for the figure")
+parser.add_argument("-gui", choices=["qt", "wx", "gtk"], default='wx',
+                    help="gui to use with IPython 0.11")


### PR DESCRIPTION
one might consider updating gui selection for ipython 0.10 as well.

however, i do think that none of this is really necessary. one can run pysurfer with ipython at all. simply use mlab.show()
