### PR TITLE
traitsui in Debian

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -22,7 +22,10 @@ except ImportError:
 try:
     from traits.ui.api import View, Item, VSplit, HSplit, Group
 except ImportError:
-    from enthought.traits.ui.api import View, Item, VSplit, HSplit, Group
+    try:
+        from traitsui.api import View, Item, VSplit, HSplit, Group
+    except ImportError:
+        from enthought.traits.ui.api import View, Item, VSplit, HSplit, Group
 
 lh_viewdict = {'lateral': {'v': (180., 90.), 'r': 90.},
                 'medial': {'v': (0., 90.), 'r': -90.},


### PR DESCRIPTION
In Debian Wheezy, traits.ui does not exist, but there is only traitsui
http://packages.debian.org/wheezy/python-traitsui
So, make import more flexible. I hope that the nesting of try-except is not too ugly.

Cheers,
G
