### PR TITLE
Fix error for ipython <0.11

### DIFF
--- a/bin/pysurfer
+++ b/bin/pysurfer
@@ -45,7 +45,7 @@ if __name__ == '__main__':
         import IPython
         if IPython.__version__ < '0.11':
             flag = '-nobanner '
-            flag += '-wthread'
+            flag += '-wthread '
         else:
             flag = '--no-banner '
             flag += '--gui=wx -i '


### PR DESCRIPTION
When re-exec'ing ipython for versions <0.11, the lack of space after '-wthread' causes the pysurfer file to be considered part of the flag, and the arguments to be the file to be executed.
