### PR TITLE
FIX: adding missing docstring to Brain

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -152,6 +152,9 @@ class Brain(object):
             title for the mayavi figure
         config_opts : dict
             options to override visual options in config file
+        figure : instance of mayavi.core.scene.Scene | None
+            If None, the last figure will be cleaned and a new figure will
+            be created.
         subjects_dir : str | None
             If not None, this directory will be used as the subjects directory
             instead of the value set using the SUBJECTS_DIR environment


### PR DESCRIPTION
Figure argument doc was missing. Minor. I came across this because I would like `mne.viz.plot_source_estimates` to be able to create new figures without cleaning the existing ones, e.g. to compare SSP / other parameters at the inverse stage.
