### PR TITLE
FIX: Explicit int to suppress numpy warning

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1345,7 +1345,8 @@ class Brain(object):
         n_colors2 = int(n_colors / 2)
 
         # Index of fmid in new colorbar
-        fmid_idx = np.round(n_colors * ((fmid - fmin) / (fmax - fmin))) - 1
+        fmid_idx = int(np.round(n_colors * ((fmid - fmin) / (fmax - fmin)))
+                       - 1)
 
         # Go through channels
         for i in range(4):


### PR DESCRIPTION
Latest numpy throws a warning about a future error if slice limits are not ints, this explicitly makes subsequent lines use one.
