### PR TITLE
ENH Brain.add_label(): use the label.hemi and label.color attributes

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1001,7 +1001,7 @@ class Brain(object):
             label filepath or name. Can also be an instance of
             an object with attributes "hemi", "vertices", "name", and
             optionally "color" and "values" (if scalar_thresh is not None).
-        color : matplotlib-style color
+        color : matplotlib-style color | None
             anything matplotlib accepts: string, RGB, hex, etc. (default
             "crimson")
         alpha : float in [0, 1]


### PR DESCRIPTION
When plotting Label instance, use the `label.hemi` attribute
