### PR TITLE
SETUP:  add nibabel to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ def check_dependencies():
 
     needed_deps = ["IPython",
                    "numpy", "scipy", "matplotlib",
-                   "nibabel",
                    "mayavi",
                    ]
     missing_deps = []
@@ -92,4 +91,5 @@ if __name__ == "__main__":
           platforms='any',
           packages=['surfer', 'surfer.tests'],
           scripts=['bin/pysurfer'],
+          install_requires=['nibabel >= 1.2'],
           )


### PR DESCRIPTION
As discussed in https://github.com/nipy/PySurfer/issues/113

Nibabel seems to have the freesurfer package since 1.2, so I specified 1.2 as the minimum requirement. Is there a reason to require 1.3?
