### PR TITLE
RF Use nibabel.freesurfer.read_label

### DIFF
--- a/surfer/io.py
+++ b/surfer/io.py
@@ -71,31 +71,6 @@ def read_scalar_data(filepath):
     return scalar_data
 
 
-def read_label(filepath, read_scalars=False):
-    """Load in a Freesurfer .label file.
-
-    Parameters
-    ----------
-    filepath : str
-        Path to label file
-    read_scalars : bool
-        If true, read and return scalars associated with each vertex
-
-    Returns
-    -------
-    label_array : numpy array (ints)
-        Array with indices of vertices included in label
-    scalar_array : numpy array (floats)
-        If read_scalars is True, array of scalar data for each vertex
-
-    """
-    label_array = np.loadtxt(filepath, dtype=np.int, skiprows=2, usecols=[0])
-    if read_scalars:
-        scalar_array = np.loadtxt(filepath, skiprows=2, usecols=[-1])
-        return label_array, scalar_array
-    return label_array
-
-
 def read_stc(filepath):
     """Read an STC file from the MNE package
 

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -256,7 +256,7 @@ def test_probabilistic_labels():
 
     label_file = pjoin(subj_dir, "fsaverage", "label", "lh.BA6.label")
     prob_field = np.zeros_like(brain._geo.x)
-    ids, probs = io.read_label(label_file, read_scalars=True)
+    ids, probs = nib.freesurfer.read_label(label_file, read_scalars=True)
     prob_field[ids] = probs
     brain.add_data(prob_field, thresh=1e-5)
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1055,9 +1055,10 @@ class Brain(object):
                                      % filepath)
             # Load the label data and create binary overlay
             if scalar_thresh is None:
-                ids = io.read_label(filepath)
+                ids = nib.freesurfer.read_label(filepath)
             else:
-                ids, scalars = io.read_label(filepath, read_scalars=True)
+                ids, scalars = nib.freesurfer.read_label(filepath,
+                                                         read_scalars=True)
                 ids = ids[scalars >= scalar_thresh]
         else:
             # try to extract parameters from label instance


### PR DESCRIPTION
Continuing on the process from #47. nibabel has had the updated read_label since nipy/nibabel@a798fa9. With the release of nibabel 2.0.0, it seems a good time to consider updating.
