### PR TITLE
Fix errors that were crashing doc build

### DIFF
--- a/examples/plot_morphometry.py
+++ b/examples/plot_morphometry.py
@@ -32,8 +32,7 @@ left hemisphere.
 brain.add_morphometry("sulc", hemi='lh', grayscale=True)
 
 """
-The Brain object can only hold one morphometry
-overlay at a time, so adding a new one removes
-any existing overlays.
+You can also use a custom colormap and tweak its range.
 """
-brain.add_morphometry("thickness")
+brain.add_morphometry("thickness",
+                      colormap="PuBuGn", min=1, max=4)

--- a/examples/plot_probabilistic_label.py
+++ b/examples/plot_probabilistic_label.py
@@ -11,7 +11,8 @@ to help characterize the location of your data.
 from os import environ
 from os.path import join
 import numpy as np
-from surfer import Brain, io
+from surfer import Brain
+from nibabel.freesurfer import read_label
 
 print(__doc__)
 
@@ -44,6 +45,6 @@ subjects_dir = environ["SUBJECTS_DIR"]
 label_file = join(subjects_dir, "fsaverage", "label", "lh.BA6.label")
 
 prob_field = np.zeros_like(brain._geo.x)
-ids, probs = io.read_label(label_file, read_scalars=True)
+ids, probs = read_label(label_file, read_scalars=True)
 prob_field[ids] = probs
 brain.add_data(prob_field, thresh=1e-5, colormap="RdPu")

--- a/examples/plot_topographic_contours.py
+++ b/examples/plot_topographic_contours.py
@@ -39,21 +39,6 @@ behind the scenes for us.  Here let's specify a different number of
 contours and use a different line width.
 """
 brain.add_contour_overlay(overlay_file,
-                          max=20,
-                          n_contours=9,
+                          min=2, max=20,
+                          n_contours=10,
                           line_width=2)
-
-"""
-At the moment, the Brain object itself does not expose an interface
-to manipulate what the contour overlay looks like after it has been
-loaded, but if you know a little bit about the underlying Mayavi
-engine, you can control aspects of the visualization through the
-contour dictionary attribute.
-"""
-brain.contour['surface'].actor.property.line_width = 1
-brain.contour['surface'].contour.number_of_contours = 10
-
-"""
-We can save several different views of this hemisphere to one file.
-"""
-brain.save_montage('examples/fmri_activation.png', colorbar='auto')

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -691,6 +691,7 @@ class Brain(object):
         return scalar_data, name
 
     def _get_display_range(self, scalar_data, min, max, sign):
+
         if scalar_data.min() >= 0:
             sign = "pos"
         elif scalar_data.max() <= 0:
@@ -705,12 +706,16 @@ class Brain(object):
             range_data = np.abs(scalar_data)
 
         # Get a numeric value for the scalar minimum
+        if min is None:
+            min = "robust_min"
         if min == "robust_min":
             min = stats.scoreatpercentile(range_data, 2)
         elif min == "actual_min":
             min = range_data.min()
 
         # Get a numeric value for the scalar maximum
+        if max is None:
+            max = "robust_max"
         if max == "robust_max":
             max = stats.scoreatpercentile(scalar_data, 98)
         elif max == "actual_max":


### PR DESCRIPTION
GH-#115 removed surfer.io.read_label but did not change the example
that was referencing it. I'm surprised that got through Travis--
does Travis not build the docs?

While fixing this I also noticed a couple of things that had gotten
out of date and fixed an oversight from the config file removal.