### PR TITLE
Fix sample floatingpoint offby1

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2169,7 +2169,7 @@ class Brain(object):
 
         # find indexes at which to create frames
         tstep = 1. / (framerate * time_dilation)
-        if (tmax - tmin) % tstep == 0:
+        if np.allclose(((tmax - tmin) % tstep, 0)):
             tstop = tmax + tstep / 2.
         else:
             tstop = tmax

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2169,7 +2169,7 @@ class Brain(object):
 
         # find indexes at which to create frames
         tstep = 1. / (framerate * time_dilation)
-        if np.allclose(((tmax - tmin) % tstep, 0)):
+        if np.allclose((tmax - tmin) % tstep, 0):
             tstop = tmax + tstep / 2.
         else:
             tstop = tmax


### PR DESCRIPTION
I noticed that `save_movie()` was creating movies slightly shorter than the desired length -- a 6 second movie would become a 5.8 seconds movie, for instance.

I think this is primarily an issue in ffmpeg which would be almost impossible to solve, but I also noticed a minor floating point instability in the calculation of the number of samples in my data.