### PR TITLE
ENH:  Time-label consistency over time

### DIFF
--- a/examples/save_movie.py
+++ b/examples/save_movie.py
@@ -27,8 +27,8 @@ for hemi in ['lh', 'rh']:
     data = stc['data']
     times = np.arange(data.shape[1]) * stc['tstep'] + stc['tmin']
     brain.add_data(data, colormap='hot', vertices=stc['vertices'],
-                   smoothing_steps=10, time=times, time_label='%0.3f s',
-                   hemi=hemi)
+                   smoothing_steps=10, time=times, hemi=hemi,
+                   time_label=lambda t: '%s ms' % int(round(t * 1e3)))
 
 """
 scale colormap

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -895,8 +895,9 @@ class Brain(object):
                 bars.append(bar)
                 row, col = np.unravel_index(bi, self.brain_matrix.shape)
                 if array.ndim == 2 and time_label is not None:
-                    self.add_text(0.05, y_txt, time_label(time[0]),
-                                  name="time_label", row=row, col=col)
+                    self.add_text(0.95, y_txt, time_label(time[0]),
+                                  name="time_label", row=row, col=col,
+                                  font_size=14, justification='right')
         self._toggle_render(True, views)
         data['surfaces'] = surfs
         data['colorbars'] = bars
@@ -1385,7 +1386,7 @@ class Brain(object):
         self._toggle_render(True, views)
 
     def add_text(self, x, y, text, name, color=None, opacity=1.0,
-                 row=-1, col=-1):
+                 row=-1, col=-1, font_size=None, justification=None):
         """ Add a text to the visualization
 
         Parameters
@@ -1412,6 +1413,11 @@ class Brain(object):
         text = self.brain_matrix[row, col].add_text(x, y, text,
                                                     name, color, opacity)
         self.texts_dict[name] = dict(row=row, col=col, text=text)
+        if font_size is not None:
+            text.property.font_size = font_size
+            text.actor.text_scale_mode = 'viewport'
+        if justification is not None:
+            text.property.justification = justification
 
     def update_text(self, text, name, row=-1, col=-1):
         """Update text label

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -767,7 +767,7 @@ class Brain(object):
                  colormap="RdBu_r", alpha=1,
                  vertices=None, smoothing_steps=20, time=None,
                  time_label="time index=%d", colorbar=True,
-                 hemi=None, remove_existing=False):
+                 hemi=None, remove_existing=False, time_label_size=14):
         """Display data from a numpy array on the surface.
 
         This provides a similar interface to add_overlay, but it displays
@@ -820,6 +820,8 @@ class Brain(object):
         remove_existing : bool
             Remove surface added by previous "add_data" call. Useful for
             conserving memory when displaying different data in a loop.
+        time_label_size : int
+            Font size of the time label (default 14)
         """
         hemi = self._check_hemi(hemi)
 
@@ -897,7 +899,8 @@ class Brain(object):
                 if array.ndim == 2 and time_label is not None:
                     self.add_text(0.95, y_txt, time_label(time[0]),
                                   name="time_label", row=row, col=col,
-                                  font_size=14, justification='right')
+                                  font_size=time_label_size,
+                                  justification='right')
         self._toggle_render(True, views)
         data['surfaces'] = surfs
         data['colorbars'] = bars


### PR DESCRIPTION
Mayavi's default bahavior is to change the text size when the number of characters changes, which looks  strange in a movie (see [before](https://www.dropbox.com/s/j551izzp9o405d9/example_before.mov?dl=0)). This PR tries to fix this tentatively by using a constant font size and right-aligning the label (see [after](https://www.dropbox.com/s/9xjjwc7gj10yswp/example_after.mov?dl=0)). I don't know how much of this should be exposed in `Brain.add_data()`, maybe at least the font size?
 