### PR TITLE
BF: env can print lines without "="

### DIFF
--- a/surfer/io.py
+++ b/surfer/io.py
@@ -176,7 +176,8 @@ def project_volume_data(filepath, hemi, reg_file=None, subject_id=None,
         cmd = ['bash', '-c', 'source {} && env'.format(
                os.path.join(env['FREESURFER_HOME'], 'FreeSurferEnv.sh'))]
         envout = check_output(cmd)
-        env = dict(line.split('=', 1) for line in envout.split('\n') if line)
+        env = dict(line.split('=', 1) for line in envout.split('\n')
+                   if '=' in line)
 
     # Set the basic commands
     cmd_list = ["mri_vol2surf",


### PR DESCRIPTION
This prevents trying to create a key, value pair from a line that can't be split on `=` when reading output from `env`.

Closes #144.