### PR TITLE
[MRG] FIX:  make screenshot() before starting movie

### DIFF
--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -37,6 +37,7 @@ def test_offscreen():
     """
     mlab.options.backend = 'auto'
     brain = Brain(*std_args, offscreen=True)
+    _ = brain.screenshot()
     shot = brain.screenshot()
     assert_array_equal(shot.shape, (800, 800, 3))
     brain.close()

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -37,6 +37,8 @@ def test_offscreen():
     """
     mlab.options.backend = 'auto'
     brain = Brain(*std_args, offscreen=True)
+    # Sometimes the first screenshot is rendered with a different
+    # resolution on OS X
     _ = brain.screenshot()
     shot = brain.screenshot()
     assert_array_equal(shot.shape, (800, 800, 3))

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -39,7 +39,7 @@ def test_offscreen():
     brain = Brain(*std_args, offscreen=True)
     # Sometimes the first screenshot is rendered with a different
     # resolution on OS X
-    _ = brain.screenshot()
+    brain.screenshot()
     shot = brain.screenshot()
     assert_array_equal(shot.shape, (800, 800, 3))
     brain.close()

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2251,7 +2251,7 @@ class Brain(object):
         logger.debug("Save movie for time points/samples\n%s\n%s"
                      % (times, time_idx))
         # Sometimes the first screenshot is rendered with a different
-        # resolution
+        # resolution on OS X
         _ = self.screenshot()
         images = (self.screenshot() for _ in
                   self._iter_time(time_idx, interpolation))

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2252,7 +2252,7 @@ class Brain(object):
                      % (times, time_idx))
         # Sometimes the first screenshot is rendered with a different
         # resolution on OS X
-        _ = self.screenshot()
+        self.screenshot()
         images = (self.screenshot() for _ in
                   self._iter_time(time_idx, interpolation))
         imageio.mimwrite(fname, images, **kwargs)

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2250,6 +2250,9 @@ class Brain(object):
 
         logger.debug("Save movie for time points/samples\n%s\n%s"
                      % (times, time_idx))
+        # Sometimes the first screenshot is rendered with a different
+        # resolution
+        _ = self.screenshot()
         images = (self.screenshot() for _ in
                   self._iter_time(time_idx, interpolation))
         imageio.mimwrite(fname, images, **kwargs)


### PR DESCRIPTION
I sometimes get an issue where the first `screenshot()` is returned at a different resolution (traceback below). If this is not just my system then this PR would fix that.

```
In [6]: brain.save_movie('R2262-loosetttt.mov', time_dilation=.004)
WARNING:root:IMAGEIO FFMPEG_WRITER WARNING: input image is not divisible by macro_block_size=16, resizing from (739, 800) to (752, 800) to ensure video compatibility with most codecs and players. To prevent resizing, make your input image divisible by the macro_block_size or set the macro_block_size to None (risking incompatibility). You may also see a FFMPEG warning concerning speedloss due to data not being aligned.
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-ca7ef3819486> in <module>()
----> 1 brain.save_movie('R2262-loosetttt.mov', time_dilation=.004)

/Users/christian/Code/PySurfer/surfer/viz.py in save_movie(self, fname, time_dilation, tmin, tmax, framerate, interpolation, codec, bitrate, **kwargs)
   2253         images = (self.screenshot() for _ in
   2254                   self._iter_time(time_idx, interpolation))
-> 2255         imageio.mimwrite(fname, images, **kwargs)
   2256 
   2257     def animate(self, views, n_steps=180., fname=None, use_cache=False,

/Users/christian/anaconda/envs/mayavi/lib/python2.7/site-packages/imageio/core/functions.pyc in mimwrite(uri, ims, format, **kwargs)
    316 
    317             # Add image
--> 318             writer.append_data(im)
    319 
    320     # Return a result if there is any

/Users/christian/anaconda/envs/mayavi/lib/python2.7/site-packages/imageio/core/format.pyc in append_data(self, im, meta)
    464             im = asarray(im)
    465             # Call
--> 466             return self._append_data(im, total_meta)
    467 
    468         def set_meta_data(self, meta):

/Users/christian/anaconda/envs/mayavi/lib/python2.7/site-packages/imageio/plugins/ffmpeg.pyc in _append_data(self, im, meta)
    559             # Check size of image
    560             if size != self._size:
--> 561                 raise ValueError('All images in a movie should have same size')
    562             if depth != self._depth:
    563                 raise ValueError('All images in a movie should have same '

ValueError: All images in a movie should have same size
```