### PR TITLE
[MRG] figure args

### DIFF
--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -75,6 +75,8 @@ def test_brains():
     # testing backend breaks when passing in a figure, so we use 'auto' here
     # (shouldn't affect usability, but it makes testing more annoying)
     mlab.options.backend = 'auto'
+    with warnings.catch_warnings(record=True):  # traits for mlab.figure()
+        mlab.figure(101)
     surfs = ['inflated', 'white', 'white', 'white', 'white', 'white', 'white']
     hemis = ['lh', 'rh', 'both', 'both', 'rh', 'both', 'both']
     titles = [None, 'Hello', 'Good bye!', 'lut test',
@@ -88,7 +90,7 @@ def test_brains():
     foregrounds = ["black", "white", "0.75", "red",
                    (0.2, 0.2, 0.2), "blue", "black"]
     with warnings.catch_warnings(record=True):  # traits for mlab.figure()
-        figs = [None, mlab.figure(), None, None, mlab.figure(), None, None]
+        figs = [101, mlab.figure(), None, None, mlab.figure(), None, None]
     subj_dirs = [None, subj_dir, subj_dir, subj_dir,
                  subj_dir, subj_dir, subj_dir]
     alphas = [1.0, 0.5, 0.25, 0.7, 0.5, 0.25, 0.7]

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -197,10 +197,6 @@ def _make_viewer(figure, n_row, n_col, title, scene_size, offscreen):
     is returned to the command line. With the multi-view, TraitsUI
     unfortunately has no such support, so we only use it if needed.
     """
-    if isinstance(figure, int):
-        # use figure with specified id
-        figure = mlab.figure(figure, size=scene_size)
-
     if figure is None:
         # spawn scenes
         h, w = scene_size
@@ -224,6 +220,8 @@ def _make_viewer(figure, n_row, n_col, title, scene_size, offscreen):
                 window = _MlabGenerator(n_row, n_col, w, h, title)
                 figures, _v = window._get_figs_view()
     else:
+        if isinstance(figure, int):  # use figure with specified id
+            figure = (mlab.figure(figure, size=scene_size),)
         if not isinstance(figure, (list, tuple)):
             figure = [figure]
         if not all(isinstance(f, Scene) for f in figure):
@@ -332,9 +330,10 @@ class Brain(object):
         a square window, or the (width, height) of a rectangular window.
     background, foreground : matplotlib colors
         color of the background and foreground of the display window
-    figure : list of instances of mayavi.core.scene.Scene | None
-        If None, a new window will be created with the appropriate
-        views.
+    figure : list of mayavi.core.scene.Scene | None | int
+        If None (default), a new window will be created with the appropriate
+        views. For single view plots, the figure can be specified as int to
+        retrieve the corresponding Mayavi window.
     subjects_dir : str | None
         If not None, this directory will be used as the subjects directory
         instead of the value set using the SUBJECTS_DIR environment

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -14,6 +14,7 @@ import nibabel as nib
 from mayavi import mlab
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from mayavi.core import lut_manager
+from mayavi.core.scene import Scene
 from mayavi.core.ui.api import SceneEditor
 from mayavi.core.ui.mayavi_scene import MayaviScene
 from traits.api import (HasTraits, Range, Int, Float,
@@ -196,6 +197,10 @@ def _make_viewer(figure, n_row, n_col, title, scene_size, offscreen):
     is returned to the command line. With the multi-view, TraitsUI
     unfortunately has no such support, so we only use it if needed.
     """
+    if isinstance(figure, int):
+        # use figure with specified id
+        figure = mlab.figure(figure, size=scene_size)
+
     if figure is None:
         # spawn scenes
         h, w = scene_size
@@ -221,6 +226,8 @@ def _make_viewer(figure, n_row, n_col, title, scene_size, offscreen):
     else:
         if not isinstance(figure, (list, tuple)):
             figure = [figure]
+        if not all(isinstance(f, Scene) for f in figure):
+            raise TypeError('figure must be a mayavi scene or list of scenes')
         if not len(figure) == n_row * n_col:
             raise ValueError('For the requested view, figure must be a '
                              'list or tuple with exactly %i elements, '

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -221,8 +221,10 @@ def _make_viewer(figure, n_row, n_col, title, scene_size, offscreen):
                 figures, _v = window._get_figs_view()
     else:
         if isinstance(figure, int):  # use figure with specified id
-            figure = (mlab.figure(figure, size=scene_size),)
-        if not isinstance(figure, (list, tuple)):
+            figure = [mlab.figure(figure, size=scene_size)]
+        elif isinstance(figure, tuple):
+            figure = list(figure)
+        elif not isinstance(figure, list):
             figure = [figure]
         if not all(isinstance(f, Scene) for f in figure):
             raise TypeError('figure must be a mayavi scene or list of scenes')


### PR DESCRIPTION
The option to specify `figure` as int and the type check were in men-python (see https://github.com/mne-tools/mne-python/pull/3375), should they be included in PySurfer?
