### PR TITLE
NF: added the option to specify alpha transparency for Brain binarized curvature rendering

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,25 @@
 PySurfer Changes
 ================
 
+Version 0.7
+-----------
+
+- A new ``alpha`` keyword to the ``Brain`` constructor now controls
+  opacity of the rendered brain surface.
+- The ``curv`` keyword to the ``Brain`` constructor has been
+  deprecated. To replicate previous behavior when ``curv`` was set to
+  ``True`` simply omit the ``curv`` keyword. To replicate previous
+  behavior when ``curv`` was set to ``False``, simply set the
+  ``cortex`` keyword to None. To ease transition the ``curv`` argument
+  will still be caught and processed, but it will be removed in a
+  future release.
+- The ``cortex`` keyword to the ``Brain`` constructor now also accepts
+  a valid color specification (such as a 3-tuple with RGB values or a
+  color name) to render the cortical surface in that color without
+  rendering binary curvature values. Additionally it now also accepts
+  a dictionary with keyword arguments that are passed on to the call
+  to ``mlab.pipeline.surface``.
+
 Version 0.6
 -----------
 

--- a/bin/pysurfer
+++ b/bin/pysurfer
@@ -73,9 +73,10 @@ if __name__ == '__main__':
         from surfer import Brain
 
         # Load  up the figure and underlying brain object
-        b = Brain(args.subject_id, args.hemi, args.surf, args.curv,
-                  args.title, views=args.views, size=args.size,
-                  background=args.background, cortex=args.cortex)
+        b = Brain(args.subject_id, args.hemi, args.surf, title=args.title,
+                  cortex=args.cortex, alpha=args.alpha, size=args.size,
+                  background=args.background, foreground=args.foreground,
+                  views=args.views)
 
         # Maybe load some morphometry
         if args.morphometry is not None:

--- a/examples/plot_transparent_brain.py
+++ b/examples/plot_transparent_brain.py
@@ -1,0 +1,41 @@
+"""
+=======================
+Plot Transparent Brain
+=======================
+
+Plot a transparent brain to visualize foci below the surface.
+
+"""
+import os
+import os.path as op
+from surfer import Brain
+
+print(__doc__)
+
+subject_id = "fsaverage"
+subjects_dir = os.environ["SUBJECTS_DIR"]
+
+"""To render a transparent brain, we are specifying an alpha <
+1.0. This allows us to visualize foci that are not on the cortical
+surface. When the brain see-through, rendering of binary curvature is
+distracting, so we specify a color, rather than a color map as the
+argument for cortex:
+
+"""
+brain = Brain(subject_id, "lh", "pial", cortex='ivory', alpha=0.5)
+
+"""Here's a set of stereotaxic foci in the MNI coordinate system that
+are not on the cortical surface which we want to display.
+
+"""
+
+coords = [[-20, 10, 10],
+          [-25, 22, 15],
+          [-18, 8, 20]]
+
+"""Now we plot the foci in the brain. Because the foci are not on the
+cortical surface, they are only visible when alpha is set to < 1.0 in
+the call to Brain.
+
+"""
+brain.add_foci(coords, color="red")

--- a/examples/plot_transparent_brain.py
+++ b/examples/plot_transparent_brain.py
@@ -7,7 +7,6 @@ Plot a transparent brain to visualize foci below the surface.
 
 """
 import os
-import os.path as op
 from surfer import Brain
 
 print(__doc__)

--- a/surfer/_commandline.py
+++ b/surfer/_commandline.py
@@ -38,8 +38,6 @@ parser.add_argument("hemi", metavar="hemi", choices=["lh", "rh",
                     help="hemisphere to load")
 parser.add_argument("surf",
                     help="surface mesh (e.g. 'pial', 'inflated')")
-parser.add_argument("-no-curv", action="store_false", dest="curv",
-                    help="do not display the binarized surface curvature")
 parser.add_argument("-morphometry", metavar="MEAS",
                     help="load morphometry file (e.g. thickness, curvature)")
 parser.add_argument("-annotation", metavar="ANNOT",
@@ -64,8 +62,12 @@ parser.add_argument("-size", default=800, nargs="?",
                     help="size of the display window (in pixels)")
 parser.add_argument("-background", metavar="COLOR", default="black",
                     help="background color for display")
+parser.add_argument("-foreground", metavar="COLOR", default="white",
+                    help="foreground color for display")
 parser.add_argument("-cortex", metavar="COLOR", default="classic",
-                    help="colormap for binary cortex curvature")
+                    help="colormap or color for rendering the cortex")
+parser.add_argument("-alpha", metavar="COLOR", default="1.0",
+                    help="specifies opacity for the cortical surface")
 parser.add_argument("-title",
                     help="title to use for the figure")
 parser.add_argument("-views", nargs="*", default=['lat'],

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -73,16 +73,17 @@ def test_brains():
     # testing backend breaks when passing in a figure, so we use 'auto' here
     # (shouldn't affect usability, but it makes testing more annoying)
     mlab.options.backend = 'auto'
-    surfs = ['inflated', 'white', 'white']
-    hemis = ['lh', 'rh', 'both']
-    titles = [None, 'Hello', 'Good bye!']
-    cortices = ["low_contrast", ("Reds", 0, 1, False), 'hotpink']
-    sizes = [500, (400, 300), (300, 300)]
-    backgrounds = ["white", "blue", "black"]
-    foregrounds = ["black", "white", "0.75"]
-    figs = [None, mlab.figure(), None]
-    subj_dirs = [None, subj_dir, subj_dir]
-    alphas = [1.0, 0.5, 0.25]
+    surfs = ['inflated', 'white', 'white', 'white']
+    hemis = ['lh', 'rh', 'both', 'both']
+    titles = [None, 'Hello', 'Good bye!', 'lut test']
+    cortices = ["low_contrast", ("Reds", 0, 1, False), 'hotpink',
+                ['yellow', 'blue']]
+    sizes = [500, (400, 300), (300, 300), (300, 400)]
+    backgrounds = ["white", "blue", "black", '0.75']
+    foregrounds = ["black", "white", "0.75", 'red']
+    figs = [None, mlab.figure(), None, None]
+    subj_dirs = [None, subj_dir, subj_dir, subj_dir]
+    alphas = [1.0, 0.5, 0.25, 0.7]
     for surf, hemi, title, cort, s, bg, fg, fig, sd, alpha \
             in zip(surfs, hemis, titles, cortices, sizes,
                    backgrounds, foregrounds, figs, subj_dirs, alphas):

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -88,7 +88,7 @@ def test_brains():
                    backgrounds, foregrounds, figs, subj_dirs, alphas):
         brain = Brain(subject_id, hemi, surf, title=title, cortex=cort,
                       alpha=alpha, size=s, background=bg, foreground=fg,
-                      figure=fig, subj_dir=sd)
+                      figure=fig, subjects_dir=sd)
         brain.close()
     assert_raises(ValueError, Brain, subject_id, 'lh', 'inflated',
                   subjects_dir='')

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -73,17 +73,17 @@ def test_brains():
     # testing backend breaks when passing in a figure, so we use 'auto' here
     # (shouldn't affect usability, but it makes testing more annoying)
     mlab.options.backend = 'auto'
-    surfs = ['inflated', 'white', 'white', 'white']
-    hemis = ['lh', 'rh', 'both', 'both']
-    titles = [None, 'Hello', 'Good bye!', 'lut test']
+    surfs = ['inflated', 'white', 'white', 'white', 'white', 'white', 'white']
+    hemis = ['lh', 'rh', 'both', 'both', 'rh', 'both', 'both']
+    titles = [None, 'Hello', 'Good bye!', 'lut test', 'dict test', 'None test', 'RGB test']
     cortices = ["low_contrast", ("Reds", 0, 1, False), 'hotpink',
-                ['yellow', 'blue']]
-    sizes = [500, (400, 300), (300, 300), (300, 400)]
-    backgrounds = ["white", "blue", "black", '0.75']
-    foregrounds = ["black", "white", "0.75", 'red']
-    figs = [None, mlab.figure(), None, None]
-    subj_dirs = [None, subj_dir, subj_dir, subj_dir]
-    alphas = [1.0, 0.5, 0.25, 0.7]
+                ['yellow', 'blue'], dict(colormap='Grays'), None, (0.5, 0.5, 0.5)]
+    sizes = [500, (400, 300), (300, 300), (300, 400), 500, 400, 300]
+    backgrounds = ["white", "blue", "black", "0.75", (0.2, 0.2, 0.2), "black", "0.75"]
+    foregrounds = ["black", "white", "0.75", "red", (0.2, 0.2, 0.2), "blue", "black"]
+    figs = [None, mlab.figure(), None, None, mlab.figure(), None, None]
+    subj_dirs = [None, subj_dir, subj_dir, subj_dir, subj_dir, subj_dir, subj_dir]
+    alphas = [1.0, 0.5, 0.25, 0.7, 0.5, 0.25, 0.7]
     for surf, hemi, title, cort, s, bg, fg, fig, sd, alpha \
             in zip(surfs, hemis, titles, cortices, sizes,
                    backgrounds, foregrounds, figs, subj_dirs, alphas):

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -75,14 +75,19 @@ def test_brains():
     mlab.options.backend = 'auto'
     surfs = ['inflated', 'white', 'white', 'white', 'white', 'white', 'white']
     hemis = ['lh', 'rh', 'both', 'both', 'rh', 'both', 'both']
-    titles = [None, 'Hello', 'Good bye!', 'lut test', 'dict test', 'None test', 'RGB test']
+    titles = [None, 'Hello', 'Good bye!', 'lut test',
+              'dict test', 'None test', 'RGB test']
     cortices = ["low_contrast", ("Reds", 0, 1, False), 'hotpink',
-                ['yellow', 'blue'], dict(colormap='Greys'), None, (0.5, 0.5, 0.5)]
+                ['yellow', 'blue'], dict(colormap='Greys'),
+                None, (0.5, 0.5, 0.5)]
     sizes = [500, (400, 300), (300, 300), (300, 400), 500, 400, 300]
-    backgrounds = ["white", "blue", "black", "0.75", (0.2, 0.2, 0.2), "black", "0.75"]
-    foregrounds = ["black", "white", "0.75", "red", (0.2, 0.2, 0.2), "blue", "black"]
+    backgrounds = ["white", "blue", "black", "0.75",
+                   (0.2, 0.2, 0.2), "black", "0.75"]
+    foregrounds = ["black", "white", "0.75", "red",
+                   (0.2, 0.2, 0.2), "blue", "black"]
     figs = [None, mlab.figure(), None, None, mlab.figure(), None, None]
-    subj_dirs = [None, subj_dir, subj_dir, subj_dir, subj_dir, subj_dir, subj_dir]
+    subj_dirs = [None, subj_dir, subj_dir, subj_dir,
+                 subj_dir, subj_dir, subj_dir]
     alphas = [1.0, 0.5, 0.25, 0.7, 0.5, 0.25, 0.7]
     for surf, hemi, title, cort, s, bg, fg, fig, sd, alpha \
             in zip(surfs, hemis, titles, cortices, sizes,

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -73,21 +73,22 @@ def test_brains():
     # testing backend breaks when passing in a figure, so we use 'auto' here
     # (shouldn't affect usability, but it makes testing more annoying)
     mlab.options.backend = 'auto'
-    surfs = ['inflated', 'white']
-    hemis = ['lh', 'rh']
-    curvs = [True, False]
-    titles = [None, 'Hello']
-    cortices = ["low_contrast", ("Reds", 0, 1, False)]
-    sizes = [500, (400, 300)]
-    backgrounds = ["white", "blue"]
-    foregrounds = ["black", "white"]
-    figs = [None, mlab.figure()]
-    subj_dirs = [None, subj_dir]
-    for surf, hemi, curv, title, cort, s, bg, fg, fig, sd \
-            in zip(surfs, hemis, curvs, titles, cortices, sizes,
-                   backgrounds, foregrounds, figs, subj_dirs):
-        brain = Brain(subject_id, hemi, surf, curv, title,
-                      cort, s, bg, fg, fig, sd)
+    surfs = ['inflated', 'white', 'white']
+    hemis = ['lh', 'rh', 'both']
+    titles = [None, 'Hello', 'Good bye!']
+    cortices = ["low_contrast", ("Reds", 0, 1, False), 'hotpink']
+    sizes = [500, (400, 300), (300, 300)]
+    backgrounds = ["white", "blue", "black"]
+    foregrounds = ["black", "white", "0.75"]
+    figs = [None, mlab.figure(), None]
+    subj_dirs = [None, subj_dir, subj_dir]
+    alphas = [1.0, 0.5, 0.25]
+    for surf, hemi, title, cort, s, bg, fg, fig, sd, alpha \
+            in zip(surfs, hemis, titles, cortices, sizes,
+                   backgrounds, foregrounds, figs, subj_dirs, alphas):
+        brain = Brain(subject_id, hemi, surf, title=title, cortex=cort,
+                      alpha=alpha, size=s, background=bg, foreground=fg,
+                      figure=fig, subj_dir=sd)
         brain.close()
     assert_raises(ValueError, Brain, subject_id, 'lh', 'inflated',
                   subjects_dir='')

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -77,7 +77,7 @@ def test_brains():
     hemis = ['lh', 'rh', 'both', 'both', 'rh', 'both', 'both']
     titles = [None, 'Hello', 'Good bye!', 'lut test', 'dict test', 'None test', 'RGB test']
     cortices = ["low_contrast", ("Reds", 0, 1, False), 'hotpink',
-                ['yellow', 'blue'], dict(colormap='Grays'), None, (0.5, 0.5, 0.5)]
+                ['yellow', 'blue'], dict(colormap='Greys'), None, (0.5, 0.5, 0.5)]
     sizes = [500, (400, 300), (300, 300), (300, 400), 500, 400, 300]
     backgrounds = ["white", "blue", "black", "0.75", (0.2, 0.2, 0.2), "black", "0.75"]
     foregrounds = ["black", "white", "0.75", "red", (0.2, 0.2, 0.2), "blue", "black"]

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -566,12 +566,12 @@ class Brain(object):
                                        vmin=-.2, vmax=2,
                                        opacity=alpha), True, True))
         if isinstance(cortex, dict):
-            if not 'opacity' in cortex:
+            if 'opacity' not in cortex:
                 cortex['opacity'] = alpha
             if 'colormap' in cortex:
-                if not 'vmin' in cortex:
+                if 'vmin' not in cortex:
                     cortex['vmin'] = -1
-                if not 'vmax' in cortex:
+                if 'vmax' not in cortex:
                     cortex['vmax'] = 2
             geo_params = cortex, False, True
         elif cortex in colormap_map:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -604,7 +604,7 @@ class Brain(object):
             geo_params = dict(colormap=cortex[0], vmin=cortex[1],
                               vmax=cortex[2], opacity=alpha), cortex[3], True
         else:
-            try: # check if it's a non-string color specification
+            try:  # check if it's a non-string color specification
                 color = colorConverter.to_rgb(cortex)
                 geo_params = dict(color=color, opacity=alpha), False, False
             except ValueError:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -297,21 +297,24 @@ class Brain(object):
     title : str
         title for the window
     cortex : str, tuple, dict, or None
-        Specifies how the cortical surface is rendered. Accepts
-        specification of a colormap (in which case binarized curvature
-        values are rendered) or a color (in which case the cortical
-        surface is rendered without binarized curvature values).  Can
-        be set to: (1) the name of one of the preset cortex styles
-        ('classic' [default], 'high_contrast', 'low_contrast', or
-        'bone'), (2) the name of a colormap, (3) a tuple with four
-        entries for (colormap, vmin, vmax, reverse) indicating the
-        name of the colormap, the min and max values respectively and
-        whether or not the colormap should be reversed, (4) a valid
-        color specification (such as a 3-tuple with RGB values or a
-        valid color name), or (5) a dictionary of keyword arguments
-        that is passed on to the call to surface. If set to `None`,
-        color is set to (0.5, 0.5, 0.5) rendering a gray brain without
-        binarized curvature.
+        Specifies how the cortical surface is rendered. Options:
+
+            1. The name of one of the preset cortex styles:
+               ``'classic'`` (default), ``'high_contrast'``,
+               ``'low_contrast'``, or ``'bone'``.
+            2. A color-like argument to render the cortex as a single
+               color, e.g. ``'red'`` or ``(0.1, 0.4, 1.)``. Setting
+               this to ``None`` is equivalent to ``(0.5, 0.5, 0.5)``.
+            3. The name of a colormap used to render binarized
+               curvature values, e.g., ``Grays``.
+            4. A container with four entries for colormap (string
+               specifiying the name of a colormap), vmin (float
+               specifying the minimum value for the colormap), vmax
+               (float specifying the maximum value for the colormap),
+               and reverse (bool specifying whether the colormap
+               should be reversed. E.g., ``('Greys', -1, 2, False)``.
+            5. A dict of keyword arguments that is passed on to the
+               call to surface.
     alpha : float in [0, 1]
         Alpha level to control opacity of the cortical surface.
     size : float or pair of floats

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -566,12 +566,12 @@ class Brain(object):
                                        vmin=-.2, vmax=2,
                                        opacity=alpha), True, True))
         if isinstance(cortex, dict):
-            if not cortex.has_key('opacity'):
+            if not 'opacity' in cortex:
                 cortex['opacity'] = alpha
-            if cortex.has_key('colormap'):
-                if not cortex.has_key('vmin'):
+            if 'colormap' in cortex:
+                if not 'vmin' in cortex:
                     cortex['vmin'] = -1
-                if not cortex.has_key('vmax'):
+                if not 'vmax' in cortex:
                     cortex['vmax'] = 2
             geo_params = cortex, False, True
         elif cortex in colormap_map:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -591,7 +591,7 @@ class Brain(object):
                     color = colorConverter.to_rgb(cortex)
                     geo_params = dict(color=color, opacity=alpha), False, False
                 except ValueError:
-                    pass
+                    geo_params = cortex, False, True
         # check for None before checking len:
         elif cortex is None:
             geo_params = dict(color=(0.5, 0.5, 0.5),

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -294,17 +294,22 @@ class Brain(object):
         in different viewing panes.
     surf :  geometry name
         freesurfer surface mesh name (ie 'white', 'inflated', etc.)
-    curv : boolean
-        if true, loads curv file and displays binary curvature
-        (default: True)
     title : str
         title for the window
-    cortex : str or tuple
-        specifies how binarized curvature values are rendered.
-        either the name of a preset PySurfer cortex colorscheme (one of
-        'classic', 'bone', 'low_contrast', or 'high_contrast'), or the
-        name of mayavi colormap, or a tuple with values (colormap, min,
-        max, reverse, alpha) to fully specify the curvature colors.
+    cortex : str, tuple, or dict
+        Specifies if/how binarized curvature values are rendered.  If
+        binarized curvature values should be rendered it can be
+        either the name of a preset PySurfer cortex colorscheme (one
+        of 'classic' (default), 'bone', 'low_contrast', or
+        'high_contrast'), the name of a mayavi colormap, a 4-tuple with
+        values (colormap, min, max, reverse), or a dictionary with
+        corresponding keys to fully specify the curvature colors. If a
+        color is specified instead, the brain is rendered in that
+        color without displaying the binarized curvature values. A
+        setting of `None` produces a gray brain without binarized
+        curvature.
+    alpha : float in [0, 1]
+        Alpha level to control opacity.
     size : float or pair of floats
         the size of the window, in pixels. can be one number to specify
         a square window, or the (width, height) of a rectangular window.
@@ -335,11 +340,11 @@ class Brain(object):
         List of the underlying brain instances.
 
     """
-    def __init__(self, subject_id, hemi, surf, curv=True, title=None,
-                 cortex="classic", size=800, background="black",
+    def __init__(self, subject_id, hemi, surf, title=None,
+                 cortex="classic", alpha=1.0, size=800, background="black",
                  foreground="white", figure=None, subjects_dir=None,
                  views=['lat'], offset=True, show_toolbar=False,
-                 offscreen=False, config_opts=None):
+                 offscreen=False, config_opts=None, curv=None):
 
         # Keep backwards compatability
         if config_opts is not None:
@@ -356,6 +361,18 @@ class Brain(object):
             width = config_opts.get("width", size)
             height = config_opts.get("height", size)
             size = (width, height)
+        # Keep backwards compatability
+        if curv is not None:
+            msg = ("The `curv` keyword has been deprecated and will "
+                   "be removed in future versions. You should update your "
+                   "code and use the `cortex` keyword to specify how the "
+                   "brain surface is rendered. Setting `cortex` to `None` "
+                   "will reproduce the previous behavior when `curv` was "
+                   "set to `False`. To emulate the previous behavior for "
+                   "cases where `curv` was set to `True`, simply omit it.")
+            warn(msg)
+            if not curv:
+                cortex = None
 
         col_dict = dict(lh=1, rh=1, both=1, split=2)
         n_col = col_dict[hemi]
@@ -385,12 +402,13 @@ class Brain(object):
             geo_hemis = ['rh']
         else:
             raise ValueError('bad hemi value')
+        geo_kwargs, geo_reverse, geo_curv = self._get_geo_params(cortex, alpha)
         for h in geo_hemis:
             # Initialize a Surface object as the geometry
             geo = Surface(subject_id, h, surf, subjects_dir, offset)
             # Load in the geometry and (maybe) curvature
             geo.load_geometry()
-            if curv:
+            if geo_curv:
                 geo.load_curvature()
             self.geo[h] = geo
 
@@ -414,9 +432,9 @@ class Brain(object):
         self._toggle_render(False)
 
         # fill figures with brains
-        kwargs = dict(surf=surf, curv=curv, title=None,
-                      cortex=cortex, subjects_dir=subjects_dir,
-                      bg_color=self._bg_color, offset=offset)
+        kwargs = dict(surf=surf, geo_curv=geo_curv, geo_kwargs=geo_kwargs,
+                      geo_reverse=geo_reverse, subjects_dir=subjects_dir,
+                      bg_color=self._bg_color)
         brains = []
         brain_matrix = []
         for ri, view in enumerate(views):
@@ -491,6 +509,77 @@ class Brain(object):
 
         fg_color_rgb = colorConverter.to_rgb(foreground)
         self._fg_color = fg_color_rgb
+
+    def _get_geo_params(self, cortex, alpha=1.0):
+        """Return keyword arguments and other parameters for surface
+        rendering.
+
+        Parameters
+        ----------
+        cortex : {classic, high_contrast, low_contrast, bone, tuple}
+            The name of one of the preset cortex styles, or a tuple
+            with four entries as described in the return vales.
+        alpha : float in [0, 1]
+            Alpha level to control opacity.
+
+        Returns
+        -------
+        kwargs : dict
+            Dictionary with keyword arguments to be used for surface
+            rendering. For colormaps, keys are ['colormap', 'vmin',
+            'vmax', 'alpha'] to specify the name, minimum, maximum,
+            and alpha transparency of the colormap respectively. For
+            colors, keys are ['color', 'alpha'] to specify the name
+            and alpha transparency of the color respectively.
+        reverse : boolean
+            Boolean indicating whether a colormap should be
+            reversed. Set to False if a color (rather than a colormap)
+            is specified.
+        curv : boolean
+            Boolean indicating whether curv file is loaded and binary
+            curvature is displayed.
+
+        """
+        colormap_map = dict(classic=(dict(colormap="Greys",
+                                          vmin=-1, vmax=2,
+                                          opacity=alpha), False, True),
+                            high_contrast=(dict(colormap="Greys",
+                                                vmin=-.1, vmax=1.3,
+                                                opacity=alpha), False, True),
+                            low_contrast=(dict(colormap="Greys",
+                                               vmin=-5, vmax=5,
+                                               opacity=alpha), False, True),
+                            bone=(dict(colormap="bone",
+                                       vmin=-.2, vmax=2,
+                                       opacity=alpha), True, True))
+        if cortex in colormap_map:
+            geo_params = colormap_map[cortex]
+        elif cortex in lut_manager.lut_mode_list():
+            geo_params = dict(colormap=cortex, vmin=-1, vmax=2,
+                              opacity=alpha), False, True
+        elif isinstance(cortex, dict):
+            geo_params = cortex, False, True
+            if not geo_params[0].has_key('opacity'):
+                geo_params[0]['opacity'] = alpha
+        # check for None before checking len:
+        elif cortex is None:
+            geo_params = dict(color=(0.5, 0.5, 0.5),
+                              opacity=alpha), False, False
+        # Test for 4-tuple specifying colormap parameters. Need to
+        # avoid 4 letter strings and 4-tuples not specifying a
+        # colormap name in the first position (color can be specified
+        # as RGBA tuple, but the A value will be dropped by to_rgb()):
+        elif (not isinstance(cortex, basestring)) and (len(cortex) == 4) and (
+                isinstance(cortex[0], basestring)):
+            geo_params = dict(colormap=cortex[0], vmin=cortex[1],
+                              vmax=cortex[2], opacity=alpha), cortex[3], True
+        else:
+            try:
+                color = colorConverter.to_rgb(cortex)
+                geo_params = dict(color=color, opacity=alpha), False, False
+            except ValueError:
+                geo_params = cortex, False, True
+        return geo_params
 
     def get_data_properties(self):
         """ Get properties of the data shown
@@ -2341,8 +2430,8 @@ class Brain(object):
 
 class _Hemisphere(object):
     """Object for visualizing one hemisphere with mlab"""
-    def __init__(self, subject_id, hemi, surf, figure, geo, curv, title,
-                 cortex, subjects_dir, bg_color, offset, backend):
+    def __init__(self, subject_id, hemi, surf, figure, geo, geo_curv,
+                 geo_kwargs, geo_reverse, subjects_dir, bg_color, backend):
         if hemi not in ['lh', 'rh']:
             raise ValueError('hemi must be either "lh" or "rh"')
         # Set the identifying info
@@ -2357,16 +2446,12 @@ class _Hemisphere(object):
 
         # mlab pipeline mesh and surface for geomtery
         self._geo = geo
-        if curv:
+        if geo_curv:
             curv_data = self._geo.bin_curv
             meshargs = dict(scalars=curv_data)
-            colormap, vmin, vmax, reverse, alpha = self._get_geo_colors(cortex)
-            kwargs = dict(colormap=colormap, vmin=vmin, vmax=vmax,
-                          opacity=alpha)
         else:
             curv_data = None
             meshargs = dict()
-            kwargs = dict(color=(.5, .5, .5))
         meshargs['figure'] = self._f
         x, y, z, f = self._geo.x, self._geo.y, self._geo.z, self._geo.faces
         self._geo_mesh = mlab.pipeline.triangular_mesh_source(x, y, z, f,
@@ -2376,8 +2461,8 @@ class _Hemisphere(object):
         self._geo_mesh.data.cell_data.normals = None
         self._geo_surf = mlab.pipeline.surface(self._geo_mesh,
                                                figure=self._f, reset_zoom=True,
-                                               **kwargs)
-        if curv and reverse:
+                                               **geo_kwargs)
+        if geo_curv and geo_reverse:
             curv_bar = mlab.scalarbar(self._geo_surf)
             curv_bar.reverse_lut = True
             curv_bar.visible = False
@@ -2653,46 +2738,6 @@ class _Hemisphere(object):
                     self._f.scene.light_manager is not None:
                 for light in self._f.scene.light_manager.lights:
                     light.azimuth *= -1
-
-    def _get_geo_colors(self, cortex):
-        """Return an mlab colormap name, vmin, vmax, and alpha for binary
-        curvature.
-
-        Parameters
-        ----------
-        cortex : {classic, high_contrast, low_contrast, bone, tuple}
-            The name of one of the preset cortex styles, or a tuple
-            with five entries as described in the return vales.
-
-        Returns
-        -------
-        colormap : string
-            mlab colormap name
-        vmin : float
-            curv colormap minimum
-        vmax : float
-            curv colormap maximum
-        reverse : boolean
-            boolean indicating whether the colormap should be reversed
-        alpha : float in [0, 1]
-            alpha level to control opacity
-        
-        """
-        colormap_map = dict(classic=("Greys", -1, 2, False, 1.0),
-                            high_contrast=("Greys", -.1, 1.3, False, 1.0),
-                            low_contrast=("Greys", -5, 5, False, 1.0),
-                            bone=("bone", -.2, 2, True, 1.0))
-
-        if cortex in colormap_map:
-            color_data = colormap_map[cortex]
-        elif cortex in lut_manager.lut_mode_list():
-            color_data = cortex, -1, 2, False, 1.0
-        else:
-            if len(cortex) == 4:
-                color_data = tuple(cortex) + (1.0, )
-            else:
-                color_data = cortex
-        return color_data
 
     def _format_cbar_text(self, cbar):
         bg_color = self._bg_color

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -552,15 +552,15 @@ class Brain(object):
                             bone=(dict(colormap="bone",
                                        vmin=-.2, vmax=2,
                                        opacity=alpha), True, True))
-        if cortex in colormap_map:
+        if isinstance(cortex, dict):
+            geo_params = cortex, False, True
+            if not geo_params[0].has_key('opacity'):
+                geo_params[0]['opacity'] = alpha
+        elif cortex in colormap_map:
             geo_params = colormap_map[cortex]
         elif cortex in lut_manager.lut_mode_list():
             geo_params = dict(colormap=cortex, vmin=-1, vmax=2,
                               opacity=alpha), False, True
-        elif isinstance(cortex, dict):
-            geo_params = cortex, False, True
-            if not geo_params[0].has_key('opacity'):
-                geo_params[0]['opacity'] = alpha
         # check for None before checking len:
         elif cortex is None:
             geo_params = dict(color=(0.5, 0.5, 0.5),

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -304,7 +304,7 @@ class Brain(object):
         either the name of a preset PySurfer cortex colorscheme (one of
         'classic', 'bone', 'low_contrast', or 'high_contrast'), or the
         name of mayavi colormap, or a tuple with values (colormap, min,
-        max, reverse) to fully specify the curvature colors.
+        max, reverse, alpha) to fully specify the curvature colors.
     size : float or pair of floats
         the size of the window, in pixels. can be one number to specify
         a square window, or the (width, height) of a rectangular window.
@@ -2360,8 +2360,9 @@ class _Hemisphere(object):
         if curv:
             curv_data = self._geo.bin_curv
             meshargs = dict(scalars=curv_data)
-            colormap, vmin, vmax, reverse = self._get_geo_colors(cortex)
-            kwargs = dict(colormap=colormap, vmin=vmin, vmax=vmax)
+            colormap, vmin, vmax, reverse, alpha = self._get_geo_colors(cortex)
+            kwargs = dict(colormap=colormap, vmin=vmin, vmax=vmax,
+                          opacity=alpha)
         else:
             curv_data = None
             meshargs = dict()
@@ -2654,13 +2655,14 @@ class _Hemisphere(object):
                     light.azimuth *= -1
 
     def _get_geo_colors(self, cortex):
-        """Return an mlab colormap name, vmin, and vmax for binary curvature.
+        """Return an mlab colormap name, vmin, vmax, and alpha for binary
+        curvature.
 
         Parameters
         ----------
         cortex : {classic, high_contrast, low_contrast, bone, tuple}
             The name of one of the preset cortex styles, or a tuple
-            with four entries as described in the return vales.
+            with five entries as described in the return vales.
 
         Returns
         -------
@@ -2672,20 +2674,24 @@ class _Hemisphere(object):
             curv colormap maximum
         reverse : boolean
             boolean indicating whether the colormap should be reversed
-
+        alpha : float in [0, 1]
+            alpha level to control opacity
+        
         """
-        colormap_map = dict(classic=("Greys", -1, 2, False),
-                            high_contrast=("Greys", -.1, 1.3, False),
-                            low_contrast=("Greys", -5, 5, False),
-                            bone=("bone", -.2, 2, True))
+        colormap_map = dict(classic=("Greys", -1, 2, False, 1.0),
+                            high_contrast=("Greys", -.1, 1.3, False, 1.0),
+                            low_contrast=("Greys", -5, 5, False, 1.0),
+                            bone=("bone", -.2, 2, True, 1.0))
 
         if cortex in colormap_map:
             color_data = colormap_map[cortex]
         elif cortex in lut_manager.lut_mode_list():
-            color_data = cortex, -1, 2, False
+            color_data = cortex, -1, 2, False, 1.0
         else:
-            color_data = cortex
-
+            if len(cortex) == 4:
+                color_data = tuple(cortex) + (1.0, )
+            else:
+                color_data = cortex
         return color_data
 
     def _format_cbar_text(self, cbar):


### PR DESCRIPTION
I have added the option to specify alpha transparency for Brain binarized curvature rendering. This can be useful when plotting foci in internal structures that are otherwise obscured by the brain surface. I had considered adding an "alpha" keyword to the Brain interface, but opted instead to allow for alpha transparency to be specified in the cortex keyword. I've implemented the chance in a way that should ensure backward compatibility with code specifying the cortex keyword as a 4-tuple or string (in these cases alpha defaults to 1.0). Using a new alpha transparency keyword for the Brain constructor might make this feature more accessible and I'm happy to change the implementation accordingly if that's preferred.