### PR TITLE
Show stderr when mri_vol2surf fails

### DIFF
--- a/surfer/io.py
+++ b/surfer/io.py
@@ -225,7 +225,7 @@ def project_volume_data(filepath, hemi, reg_file=None, subject_id=None,
     out = p.returncode
     if out:
         raise RuntimeError(("mri_vol2surf command failed "
-                            "with command-line: ") + " ".join(cmd_list))
+                            "with output: \n\n{}".format(stderr)))
 
     # Read in the data
     surf_data = read_scalar_data(out_file)


### PR DESCRIPTION
This should make it easier to debug problems when using `project_volume_data`. Not sure why we were just printing the command line before (which gets printed anyway).

Closes #171.