### PR TITLE
FIX: showing multiple data layers

### DIFF
--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -219,10 +219,27 @@ def test_meg_inverse():
     assert_equal(brain.data_dict['lh']['time_idx'], 2)
     # viewer = TimeViewer(brain)
 
+    # multiple data layers
+    assert_raises(ValueError, brain.add_data, data, vertices=vertices,
+                  time=time[:-1])
     brain.add_data(data, colormap=colormap, vertices=vertices,
                    smoothing_steps=10, time=time, time_label=time_label,
-                   initial_time=.09, remove_existing=True)
+                   initial_time=.09)
     assert_equal(brain.data_dict['lh']['time_idx'], 1)
+    data_dicts = brain._data_dicts['lh']
+    assert_equal(len(data_dicts), 2)
+    assert_equal(data_dicts[0]['time_idx'], 1)
+    assert_equal(data_dicts[1]['time_idx'], 1)
+
+    # shift time in both layers
+    brain.set_data_time_index(0)
+    assert_equal(data_dicts[0]['time_idx'], 0)
+    assert_equal(data_dicts[1]['time_idx'], 0)
+
+    # remove all layers
+    brain.remove_data()
+    assert_equal(brain._data_dicts['lh'], [])
+
     brain.close()
 
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1063,14 +1063,7 @@ class Brain(object):
 
         # clean up existing data
         if remove_existing:
-            for data in self._data_dicts[hemi]:
-                for surf in data['surfaces']:
-                    surf.parent.parent.remove()
-            self._data_dicts[hemi] = []
-            # if no data is left, reset time properties
-            other_hemi = 'rh' if hemi == 'lh' else 'lh'
-            if not self._data_dicts[other_hemi]:
-                self.n_times = self._times = None
+            self.remove_data(hemi)
 
         # Create time array and add label if 2D
         if array.ndim == 2:
@@ -1368,6 +1361,26 @@ class Brain(object):
                     keep_idx = keep_idx[np.in1d(keep_idx, restrict_idx)]
             show[keep_idx] = 1
             label *= show
+
+    def remove_data(self, hemi=None):
+        """Remove data shown with ``Brain.add_data()``.
+
+        Parameters
+        ----------
+        hemi : str | None
+            Hemisphere from which to remove data (default is all shown
+            hemispheres).
+        """
+        hemis = self._check_hemis(hemi)
+        for hemi in hemis:
+            for data in self._data_dicts[hemi]:
+                for surf in data['surfaces']:
+                    surf.parent.parent.remove()
+            self._data_dicts[hemi] = []
+
+        # if no data is left, reset time properties
+        if not self._data_dicts['lh'] and not self._data_dicts['rh']:
+            self.n_times = self._times = None
 
     def remove_labels(self, labels=None, hemi=None):
         """Remove one or more previously added labels from the image.

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1083,7 +1083,7 @@ class Brain(object):
             elif len(time) != self.n_times:
                 raise ValueError("New n_times is different from previous "
                                  "n_times")
-            elif not np.all(time == self._times):
+            elif not np.array_equal(time, self._times):
                 raise ValueError("Not all time values are consistent with "
                                  "previously set times.")
 


### PR DESCRIPTION
Previously `Brain` time-setters and `.add_data(remove_existing=True)` only affected the most recently added data-layer on each hemisphere.