### PR TITLE
[MRG] FIX Brain.remove labels()

### DIFF
--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -5,7 +5,7 @@ import shutil
 from tempfile import mkdtemp, mktemp
 import warnings
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in, assert_not_in
 from mayavi import mlab
 import nibabel as nib
 import numpy as np
@@ -191,6 +191,14 @@ def test_label():
     brain.add_label("V1", color="steelblue", alpha=.6)
     brain.add_label("V2", color="#FF6347", alpha=.6)
     brain.add_label("entorhinal", color=(.2, 1, .5), alpha=.6)
+
+    # remove labels
+    brain.remove_labels('V1')
+    assert_in('V2', brain.labels_dict)
+    assert_not_in('V1', brain.labels_dict)
+    brain.remove_labels()
+    assert_not_in('V2', brain.labels_dict)
+
     brain.close()
 
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1391,12 +1391,13 @@ class Brain(object):
             Labels to remove. Can be a string naming a single label, or None to
             remove all labels. Possible names can be found in the Brain.labels
             attribute.
-        hemi : str | None
-            If None, it is assumed to belong to the hemipshere being
-            shown. If two hemispheres are being shown, an error will
-            be thrown.
+        hemi : None
+            Deprecated parameter, do not use.
         """
-        hemi = self._check_hemi(hemi)
+        if hemi is not None:
+            warn("The `hemi` parameter to Brain.remove_labels() has no effect "
+                 "and will be removed in PySurfer 0.9", DeprecationWarning)
+
         if labels is None:
             labels = self.labels_dict.keys()
         elif isinstance(labels, str):


### PR DESCRIPTION
Remove the `hemi` parameter, which was previously unused (even though it forced the user to set it). Labels are not stored by hemisphere, but by their name.