### PR TITLE
FIX toggle_render:  store camera parallel_scale

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -524,6 +524,8 @@ class Brain(object):
         for vi, (_f, view) in enumerate(zip(figs, views)):
             if state is False and view is None:
                 views[vi] = (mlab.view(figure=_f),
+                             # scene is None in testing backend
+                             1 if _f.scene is None else
                              _f.scene.camera.parallel_scale)
 
             # Testing backend doesn't have this option
@@ -534,7 +536,8 @@ class Brain(object):
                 mlab.draw(figure=_f)
                 with warnings.catch_warnings(record=True):  # traits focalpoint
                     mlab.view(*view[0], figure=_f)
-                _f.scene.camera.parallel_scale = view[1]
+                if _f.scene is not None:
+                    _f.scene.camera.parallel_scale = view[1]
         # let's do the ugly force draw
         if state is True:
             _force_render(self._figures, self._window_backend)

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -518,13 +518,13 @@ class Brain(object):
     # HELPERS
     def _toggle_render(self, state, views=None):
         """Turn rendering on (True) or off (False)"""
-        figs = []
-        [figs.extend(f) for f in self._figures]
+        figs = [fig for fig_row in self._figures for fig in fig_row]
         if views is None:
             views = [None] * len(figs)
         for vi, (_f, view) in enumerate(zip(figs, views)):
             if state is False and view is None:
-                views[vi] = mlab.view(figure=_f)
+                views[vi] = (mlab.view(figure=_f),
+                             _f.scene.camera.parallel_scale)
 
             # Testing backend doesn't have this option
             if mlab.options.backend != 'test':
@@ -533,7 +533,8 @@ class Brain(object):
             if state is True and view is not None:
                 mlab.draw(figure=_f)
                 with warnings.catch_warnings(record=True):  # traits focalpoint
-                    mlab.view(*view, figure=_f)
+                    mlab.view(*view[0], figure=_f)
+                _f.scene.camera.parallel_scale = view[1]
         # let's do the ugly force draw
         if state is True:
             _force_render(self._figures, self._window_backend)

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -522,22 +522,21 @@ class Brain(object):
         if views is None:
             views = [None] * len(figs)
         for vi, (_f, view) in enumerate(zip(figs, views)):
+            # Testing backend doesn't have these options
+            if mlab.options.backend == 'test':
+                continue
+
             if state is False and view is None:
                 views[vi] = (mlab.view(figure=_f),
-                             # scene is None in testing backend
-                             1 if _f.scene is None else
                              _f.scene.camera.parallel_scale)
 
-            # Testing backend doesn't have this option
-            if mlab.options.backend != 'test':
-                _f.scene.disable_render = not state
+            _f.scene.disable_render = not state
 
             if state is True and view is not None:
                 mlab.draw(figure=_f)
                 with warnings.catch_warnings(record=True):  # traits focalpoint
                     mlab.view(*view[0], figure=_f)
-                if _f.scene is not None:
-                    _f.scene.camera.parallel_scale = view[1]
+                _f.scene.camera.parallel_scale = view[1]
         # let's do the ugly force draw
         if state is True:
             _force_render(self._figures, self._window_backend)


### PR DESCRIPTION
`mlab.view()` does not return parallel_scale (which only becomes apparent when setting the camera to use parallel projection)