### PR TITLE
[MRG]: Set surface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 PySurfer Changes
 ================
 
+Version 0.8
+-----------
+
+- The surface geometry that is displayed can now be changed after initializing
+  a ``Brain`` instance with e.g. ``Brain.set_surf("smoothwm")``.
+
 Version 0.7
 -----------
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ Version 0.8
 -----------
 
 - The surface geometry that is displayed can now be changed after initializing
-  a ``Brain`` instance with e.g. ``Brain.set_surf("smoothwm")``.
+  a ``Brain`` instance with e.g. ``brain.set_surf("smoothwm")``.
 
 Version 0.7
 -----------

--- a/examples/plot_basics.py
+++ b/examples/plot_basics.py
@@ -16,10 +16,10 @@ in tksurfer (and pysurfer for that matter).
 """
 subject_id = 'fsaverage'
 hemi = 'lh'
-surface = 'inflated'
+surf = 'inflated'
 
 """
 Call the Brain object constructor with these
 parameters to initialize the visualization session.
 """
-brain = Brain(subject_id, hemi, surface)
+brain = Brain(subject_id, hemi, surf)

--- a/examples/plot_meg_inverse_solution.py
+++ b/examples/plot_meg_inverse_solution.py
@@ -18,13 +18,13 @@ path = os.path.dirname(__file__)
 """
 define subject, surface and hemisphere(s) to plot
 """
-subject_id, surface = 'fsaverage', 'inflated'
+subject_id, surf = 'fsaverage', 'inflated'
 hemi = 'split'
 
 """
 create Brain object for visualization
 """
-brain = Brain(subject_id, hemi, surface, size=(800, 400),
+brain = Brain(subject_id, hemi, surf, size=(800, 400),
               interaction='terrain')
 
 """

--- a/examples/plot_parc_values.py
+++ b/examples/plot_parc_values.py
@@ -17,12 +17,12 @@ print(__doc__)
 
 subject_id = "fsaverage"
 hemi = "lh"
-surface = "inflated"
+surf = "inflated"
 
 """
 Bring up the visualization.
 """
-brain = Brain(subject_id, hemi, surface, background="white")
+brain = Brain(subject_id, hemi, surf, background="white")
 
 """
 Read in the Buckner resting state network annotation. (This requires a

--- a/examples/plot_parcellation.py
+++ b/examples/plot_parcellation.py
@@ -13,13 +13,13 @@ print(__doc__)
 
 subject_id = 'fsaverage'
 hemi = 'both'
-surface = 'inflated'
+surf = 'inflated'
 view = 'frontal'
 
 """
 Bring up the visualization
 """
-brain = Brain(subject_id, hemi, surface, views=view,
+brain = Brain(subject_id, hemi, surf, views=view,
               cortex="bone", background="ivory")
 
 """

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -308,7 +308,7 @@ def test_movie():
 @requires_fsaverage
 def test_overlay():
     """Test plotting of overlay."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     # basic overlay support
     overlay_file = pjoin(data_dir, "lh.sig.nii.gz")
     brain = Brain(*std_args)

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -100,6 +100,7 @@ def test_brains():
         brain = Brain(subject_id, hemi, surf, title=title, cortex=cort,
                       alpha=alpha, size=s, background=bg, foreground=fg,
                       figure=fig, subjects_dir=sd)
+        brain.set_distance()
         brain.close()
     brain = Brain(subject_id, hemi, surf, subjects_dir=sd,
                   interaction='terrain')

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -120,7 +120,7 @@ def test_annot():
     brain = Brain(*std_args)
     for a, b, p in zip(annots, borders, alphas):
         brain.add_annotation(a, b, p)
-    brain.set_surface('smoothwm')
+    brain.set_surface('white')
     assert_raises(ValueError, brain.add_annotation, 'aparc', borders=-1)
     brain.close()
 
@@ -149,7 +149,7 @@ def test_data():
     reg_file = pjoin(data_dir, 'register.dat')
     surf_data = io.project_volume_data(mri_file, "lh", reg_file)
     brain.add_data(surf_data, -.7, .7, colormap="jet", alpha=.7)
-    brain.set_surface('smoothwm')
+    brain.set_surface('white')
     brain.add_data([], vertices=np.array([], int))
     brain.close()
 
@@ -193,7 +193,7 @@ def test_label():
     brain.add_label("V1", color="steelblue", alpha=.6)
     brain.add_label("V2", color="#FF6347", alpha=.6)
     brain.add_label("entorhinal", color=(.2, 1, .5), alpha=.6)
-    brain.set_surface('smoothwm')
+    brain.set_surface('white')
 
     # remove labels
     brain.remove_labels('V1')
@@ -248,7 +248,7 @@ def test_meg_inverse():
     assert_equal(data_dicts[1]['time_idx'], 0)
 
     # change surface
-    brain.set_surface('smoothwm')
+    brain.set_surface('white')
 
     # remove all layers
     brain.remove_data()

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -357,8 +357,9 @@ def test_probabilistic_labels():
     prob_field[ids] = probs
     brain.add_data(prob_field, thresh=1e-5)
 
-    brain.data["colorbar"].number_of_colors = 10
-    brain.data["colorbar"].number_of_labels = 11
+    with warnings.catch_warnings(record=True):
+        brain.data["colorbar"].number_of_colors = 10
+        brain.data["colorbar"].number_of_labels = 11
     brain.close()
 
 

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -113,7 +113,7 @@ def test_brains():
 @requires_fsaverage
 def test_annot():
     """Test plotting of annot."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     annots = ['aparc', 'aparc.a2005s']
     borders = [True, False, 2]
     alphas = [1, 0.5]
@@ -128,7 +128,7 @@ def test_annot():
 @requires_fsaverage
 def test_contour():
     """Test plotting of contour overlay."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     brain = Brain(*std_args)
     overlay_file = pjoin(data_dir, "lh.sig.nii.gz")
     brain.add_contour_overlay(overlay_file)
@@ -143,7 +143,7 @@ def test_contour():
 @requires_fs
 def test_data():
     """Test plotting of data."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     brain = Brain(*std_args)
     mri_file = pjoin(data_dir, 'resting_corr.nii.gz')
     reg_file = pjoin(data_dir, 'register.dat')
@@ -177,7 +177,7 @@ def test_foci():
 @requires_fsaverage
 def test_label():
     """Test plotting of label."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     subject_id = "fsaverage"
     hemi = "lh"
     surf = "inflated"
@@ -208,7 +208,7 @@ def test_label():
 @requires_fsaverage
 def test_meg_inverse():
     """Test plotting of MEG inverse solution."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     brain = Brain(*std_args)
     stc_fname = os.path.join(data_dir, 'meg_source_estimate-lh.stc')
     stc = io.read_stc(stc_fname)
@@ -260,7 +260,7 @@ def test_meg_inverse():
 @requires_fsaverage
 def test_morphometry():
     """Test plotting of morphometry."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     brain = Brain(*std_args)
     brain.add_morphometry("curv")
     brain.add_morphometry("sulc", grayscale=True)
@@ -340,7 +340,7 @@ def test_overlay():
 @requires_fsaverage
 def test_probabilistic_labels():
     """Test plotting of probabilistic labels."""
-    mlab.options.backend = 'test'
+    mlab.options.backend = 'auto'
     brain = Brain("fsaverage", "lh", "inflated",
                   cortex="low_contrast")
 

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -120,6 +120,7 @@ def test_annot():
     brain = Brain(*std_args)
     for a, b, p in zip(annots, borders, alphas):
         brain.add_annotation(a, b, p)
+    brain.set_surface('smoothwm')
     assert_raises(ValueError, brain.add_annotation, 'aparc', borders=-1)
     brain.close()
 
@@ -148,6 +149,7 @@ def test_data():
     reg_file = pjoin(data_dir, 'register.dat')
     surf_data = io.project_volume_data(mri_file, "lh", reg_file)
     brain.add_data(surf_data, -.7, .7, colormap="jet", alpha=.7)
+    brain.set_surface('smoothwm')
     brain.add_data([], vertices=np.array([], int))
     brain.close()
 
@@ -191,6 +193,7 @@ def test_label():
     brain.add_label("V1", color="steelblue", alpha=.6)
     brain.add_label("V2", color="#FF6347", alpha=.6)
     brain.add_label("entorhinal", color=(.2, 1, .5), alpha=.6)
+    brain.set_surface('smoothwm')
 
     # remove labels
     brain.remove_labels('V1')
@@ -243,6 +246,9 @@ def test_meg_inverse():
     brain.set_data_time_index(0)
     assert_equal(data_dicts[0]['time_idx'], 0)
     assert_equal(data_dicts[1]['time_idx'], 0)
+
+    # change surface
+    brain.set_surface('smoothwm')
 
     # remove all layers
     brain.remove_data()

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -334,6 +334,9 @@ def test_overlay():
     brain.add_overlay(conjunct, 4, 30, name="conjunct")
     brain.overlays["conjunct"].pos_bar.lut_mode = "Purples"
     brain.overlays["conjunct"].pos_bar.visible = False
+
+    brain.set_surface('white')
+
     brain.close()
 
 

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -352,7 +352,7 @@ def test_probabilistic_labels():
     brain.add_label("BA45", color="salmon", borders=True, scalar_thresh=.5)
 
     label_file = pjoin(subj_dir, "fsaverage", "label", "lh.BA6.label")
-    prob_field = np.zeros_like(brain._geo.x)
+    prob_field = np.zeros_like(brain.geo['lh'].x)
     ids, probs = nib.freesurfer.read_label(label_file, read_scalars=True)
     prob_field[ids] = probs
     brain.add_data(prob_field, thresh=1e-5)

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -120,7 +120,7 @@ def test_annot():
     brain = Brain(*std_args)
     for a, b, p in zip(annots, borders, alphas):
         brain.add_annotation(a, b, p)
-    brain.set_surface('white')
+    brain.set_surf('white')
     assert_raises(ValueError, brain.add_annotation, 'aparc', borders=-1)
     brain.close()
 
@@ -149,7 +149,7 @@ def test_data():
     reg_file = pjoin(data_dir, 'register.dat')
     surf_data = io.project_volume_data(mri_file, "lh", reg_file)
     brain.add_data(surf_data, -.7, .7, colormap="jet", alpha=.7)
-    brain.set_surface('white')
+    brain.set_surf('white')
     brain.add_data([], vertices=np.array([], int))
     brain.close()
 
@@ -193,7 +193,7 @@ def test_label():
     brain.add_label("V1", color="steelblue", alpha=.6)
     brain.add_label("V2", color="#FF6347", alpha=.6)
     brain.add_label("entorhinal", color=(.2, 1, .5), alpha=.6)
-    brain.set_surface('white')
+    brain.set_surf('white')
 
     # remove labels
     brain.remove_labels('V1')
@@ -248,7 +248,7 @@ def test_meg_inverse():
     assert_equal(data_dicts[1]['time_idx'], 0)
 
     # change surface
-    brain.set_surface('white')
+    brain.set_surf('white')
 
     # remove all layers
     brain.remove_data()
@@ -335,7 +335,7 @@ def test_overlay():
     brain.overlays["conjunct"].pos_bar.lut_mode = "Purples"
     brain.overlays["conjunct"].pos_bar.visible = False
 
-    brain.set_surface('white')
+    brain.set_surf('white')
 
     brain.close()
 

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -32,7 +32,7 @@ class _MayaviThresholdPatch(object):
     In Mayavi 4.5, filters seem to be missing a .point_data attribute that
     Threshold accesses on initialization.
     """
-    need_patch = LooseVersion(mayavi.__version__) <= LooseVersion('4.5.0')
+    need_patch = LooseVersion(mayavi.__version__) == LooseVersion('4.5.0')
     _orig_func = Threshold._get_data_range
 
     @staticmethod

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -34,7 +34,10 @@ class _MayaviThresholdPatch(object):
     """
     need_patch = LooseVersion(mayavi.__version__) <= LooseVersion('4.5.0')
     _orig_func = Threshold._get_data_range
-    _patch_func = lambda x: []
+
+    @staticmethod
+    def _patch_func(self):
+        return []
 
     def __enter__(self):
         if self.need_patch:

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -76,6 +76,9 @@ class Surface(object):
         self.hemi = hemi
         self.surf = surf
         self.offset = offset
+        self.coords = None
+        self.faces = None
+        self.nn = None
 
         subjects_dir = _get_subjects_dir(subjects_dir)
         self.data_path = op.join(subjects_dir, subject_id)
@@ -83,13 +86,22 @@ class Surface(object):
     def load_geometry(self):
         surf_path = op.join(self.data_path, "surf",
                             "%s.%s" % (self.hemi, self.surf))
-        self.coords, self.faces = nib.freesurfer.read_geometry(surf_path)
+        coords, faces = nib.freesurfer.read_geometry(surf_path)
         if self.offset is not None:
             if self.hemi == 'lh':
-                self.coords[:, 0] -= (np.max(self.coords[:, 0]) + self.offset)
+                coords[:, 0] -= (np.max(coords[:, 0]) + self.offset)
             else:
-                self.coords[:, 0] -= (np.min(self.coords[:, 0]) + self.offset)
-        self.nn = _compute_normals(self.coords, self.faces)
+                coords[:, 0] -= (np.min(coords[:, 0]) + self.offset)
+        nn = _compute_normals(coords, faces)
+
+        if self.coords is None:
+            self.coords = coords
+            self.faces = faces
+            self.nn = nn
+        else:
+            self.coords[:] = coords
+            self.faces[:] = faces
+            self.nn[:] = nn
 
     def save_geometry(self):
         surf_path = op.join(self.data_path, "surf",

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -306,7 +306,7 @@ class Brain(object):
         of 'both', both hemispheres are shown in the same window.
         In the case of 'split' hemispheres are displayed side-by-side
         in different viewing panes.
-    surf :  geometry name
+    surf : str
         freesurfer surface mesh name (ie 'white', 'inflated', etc.)
     title : str
         title for the window
@@ -1751,6 +1751,13 @@ class Brain(object):
         return distance
 
     def set_surface(self, surface):
+        """Change the surface geometry
+
+        Parameters
+        ----------
+        surface : str
+            freesurfer surface mesh name (ie 'white', 'inflated', etc.)
+        """
         if self.surf == surface:
             return
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -11,7 +11,6 @@ from matplotlib.colors import colorConverter
 
 import nibabel as nib
 
-import mayavi
 from mayavi import mlab
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from mayavi.core import lut_manager

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1780,6 +1780,12 @@ class Brain(object):
 
         self.surf = surf
         self._toggle_render(True, views)
+
+        if mlab.options.backend == 'test':
+            # required SetActiveAttribute filter attributes are not set under
+            # the testing backend
+            return
+
         for brain in self.brains:
             brain._f.scene.reset_zoom()
 
@@ -2717,7 +2723,11 @@ class _Hemisphere(object):
         return (np.array(dv), dr)
 
     def _add_scalar_data(self, data):
-        # Add scalar values to dataset
+        """Add scalar values to dataset"""
+        if mlab.options.backend == 'test':
+            # required SetActiveAttribute filter attributes are not set under
+            # the testing backend
+            return 0, self._geo_mesh
         array_id = self._mesh_dataset.point_data.add_array(data)
         self._mesh_dataset.point_data.get_array(array_id).name = array_id
         self._mesh_dataset.point_data.update()
@@ -2734,7 +2744,11 @@ class _Hemisphere(object):
         return array_id, pipe
 
     def _remove_scalar_data(self, array_id):
-        "Removes scalar data"
+        """Removes scalar data"""
+        if mlab.options.backend == 'test':
+            # required SetActiveAttribute filter attributes are not set under
+            # the testing backend
+            return
         self._mesh_clones.pop(array_id).remove()
         self._mesh_dataset.point_data.remove_array(array_id)
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 from math import floor
 import os
 from os.path import join as pjoin
@@ -11,6 +12,7 @@ from matplotlib.colors import colorConverter
 
 import nibabel as nib
 
+import mayavi
 from mayavi import mlab
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from mayavi.core import lut_manager
@@ -28,6 +30,12 @@ from .utils import (Surface, verbose, create_color_lut, _get_subjects_dir,
 
 import logging
 logger = logging.getLogger('surfer')
+
+
+# Monkey-patch for Mayavi 4.5: filters are missing a point_data attribute that
+# Threshold accesses on initialization
+if LooseVersion(mayavi.__version__) <= LooseVersion('4.5.0'):
+    mayavi.filters.api.Threshold._get_data_range = lambda x: []
 
 
 lh_viewdict = {'lateral': {'v': (180., 90.), 'r': 90.},

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1750,15 +1750,15 @@ class Brain(object):
                 mlab.view(distance=distance, figure=f)
         return distance
 
-    def set_surface(self, surface):
+    def set_surf(self, surf):
         """Change the surface geometry
 
         Parameters
         ----------
-        surface : str
+        surf : str
             freesurfer surface mesh name (ie 'white', 'inflated', etc.)
         """
-        if self.surf == surface:
+        if self.surf == surf:
             return
 
         views = self._toggle_render(False)
@@ -1766,7 +1766,7 @@ class Brain(object):
         # load new geometry
         for geo in self.geo.values():
             try:
-                geo.surf = surface
+                geo.surf = surf
                 geo.load_geometry()
             except IOError:  # surface file does not exist
                 geo.surf = self.surf
@@ -1776,9 +1776,9 @@ class Brain(object):
         # update mesh objects (they use a reference to geo.coords)
         with mayavi_threshold_patch:
             for brain in self.brains:
-                brain.update_surface()
+                brain.update_surf()
 
-        self.surf = surface
+        self.surf = surf
         self._toggle_render(True, views)
 
     @verbose
@@ -2941,7 +2941,7 @@ class _Hemisphere(object):
             text_color = (0., 0., 0.)
         cbar.label_text_property.color = text_color
 
-    def update_surface(self):
+    def update_surf(self):
         "Update surface mesh after mesh coordinates change"
         self._geo_mesh.update()
         for mesh in self._mesh_clones.values():

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1205,7 +1205,6 @@ class Brain(object):
                 a['surface'].remove()
             self.annot_list = []
 
-        al = self.annot_list
         for hemi, filepath in zip(hemis, filepaths):
             # Read in the data
             labels, cmap, _ = nib.freesurfer.read_annot(filepath,
@@ -1233,8 +1232,8 @@ class Brain(object):
 
             for brain in self._brain_list:
                 if brain['hemi'] == hemi:
-                    al.append(brain['brain'].add_annotation(annot, ids, cmap))
-        self.annot_list = al
+                    self.annot_list.append(
+                        brain['brain'].add_annotation(annot, ids, cmap))
         self._toggle_render(True, views)
 
     def add_label(self, label, color=None, alpha=1, scalar_thresh=None,

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2729,7 +2729,8 @@ class _Hemisphere(object):
                 self._mesh_dataset, point_scalars=array_id, figure=self._f)
             # The new data-source is added to the wrong figure by default
             # (a Mayavi bug??)
-            self._f.add_child(pipe.parent)
+            if pipe.parent not in self._f.children:
+                self._f.add_child(pipe.parent)
         self._mesh_clones[array_id] = pipe.parent
         return array_id, pipe
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -999,7 +999,7 @@ class Brain(object):
         vertices : numpy array
             vertices for which the data is defined (needed if len(data) < nvtx)
         smoothing_steps : int or None
-            number of smoothing steps (smooting is used if len(data) < nvtx)
+            number of smoothing steps (smoothing is used if len(data) < nvtx)
             Default : 20
         time : numpy array
             time points in the data array (if data is 2D)
@@ -1009,7 +1009,7 @@ class Brain(object):
         colorbar : bool
             whether to add a colorbar to the figure
         hemi : str | None
-            If None, it is assumed to belong to the hemipshere being
+            If None, it is assumed to belong to the hemisphere being
             shown. If two hemispheres are being shown, an error will
             be thrown.
         remove_existing : bool

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1781,6 +1781,8 @@ class Brain(object):
 
         self.surf = surf
         self._toggle_render(True, views)
+        for brain in self.brains:
+            brain._f.scene.reset_zoom()
 
     @verbose
     def scale_data_colormap(self, fmin, fmid, fmax, transparent, verbose=None):

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -466,7 +466,7 @@ class Brain(object):
         self._toggle_render(False)
 
         # fill figures with brains
-        kwargs = dict(surf=surf, geo_curv=geo_curv, geo_kwargs=geo_kwargs,
+        kwargs = dict(geo_curv=geo_curv, geo_kwargs=geo_kwargs,
                       geo_reverse=geo_reverse, subjects_dir=subjects_dir,
                       bg_color=self._bg_color)
         brains = []
@@ -2579,7 +2579,7 @@ class Brain(object):
 
 class _Hemisphere(object):
     """Object for visualizing one hemisphere with mlab"""
-    def __init__(self, subject_id, hemi, surf, figure, geo, geo_curv,
+    def __init__(self, subject_id, hemi, figure, geo, geo_curv,
                  geo_kwargs, geo_reverse, subjects_dir, bg_color, backend):
         if hemi not in ['lh', 'rh']:
             raise ValueError('hemi must be either "lh" or "rh"')

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1769,7 +1769,7 @@ class Brain(object):
             try:
                 geo.surf = surface
                 geo.load_geometry()
-            except IOError:
+            except IOError:  # surface file does not exist
                 geo.surf = self.surf
                 self._toggle_render(True)
                 raise

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1121,8 +1121,8 @@ class Brain(object):
         for brain in self._brain_list:
             if brain['hemi'] == hemi:
                 s, ct, bar = brain['brain'].add_data(
-                    array, mlab_plot, vertices, smooth_mat, min, max, thresh,
-                    lut, colormap, alpha, time, time_label, colorbar, layer_id)
+                    array, mlab_plot, min, max, thresh, lut, colormap, alpha,
+                    colorbar, layer_id)
                 surfs.append(s)
                 bars.append(bar)
                 if array.ndim == 2 and time_label is not None:
@@ -2774,9 +2774,8 @@ class _Hemisphere(object):
         return OverlayDisplay(self, array_id, pos, pos_bar, neg, neg_bar)
 
     @verbose
-    def add_data(self, array, mlab_plot, vertices, smooth_mat, min, max,
-                 thresh, lut, colormap, alpha, time, time_label, colorbar,
-                 layer_id):
+    def add_data(self, array, mlab_plot, min, max, thresh, lut, colormap,
+                 alpha, colorbar, layer_id):
         """Add data to the brain"""
         # Calculate initial data to plot
         if array.ndim == 1:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1060,14 +1060,15 @@ class Brain(object):
         # determine unique data layer ID
         data_dicts = self._data_dicts['lh'] + self._data_dicts['rh']
         if data_dicts:
-            layer = np.max([data['layer'] for data in data_dicts]) + 1
+            layer_id = np.max([data['layer_id'] for data in data_dicts]) + 1
         else:
-            layer = 0
+            layer_id = 0
 
         data = dict(array=array, smoothing_steps=smoothing_steps,
                     fmin=min, fmid=(min + max) / 2, fmax=max,
                     transparent=False, time=0, time_idx=0,
-                    vertices=vertices, smooth_mat=smooth_mat, layer=layer)
+                    vertices=vertices, smooth_mat=smooth_mat,
+                    layer_id=layer_id)
 
         # clean up existing data
         if remove_existing:
@@ -1121,7 +1122,7 @@ class Brain(object):
             if brain['hemi'] == hemi:
                 s, ct, bar = brain['brain'].add_data(
                     array, mlab_plot, vertices, smooth_mat, min, max, thresh,
-                    lut, colormap, alpha, time, time_label, colorbar, layer)
+                    lut, colormap, alpha, time, time_label, colorbar, layer_id)
                 surfs.append(s)
                 bars.append(bar)
                 if array.ndim == 2 and time_label is not None:
@@ -1384,7 +1385,7 @@ class Brain(object):
             for brain in self.brains:
                 if brain.hemi == hemi:
                     for data in self._data_dicts[hemi]:
-                        brain.remove_data(data['layer'])
+                        brain.remove_data(data['layer_id'])
             self._data_dicts[hemi] = []
 
         # if no data is left, reset time properties
@@ -1893,7 +1894,7 @@ class Brain(object):
 
                 for brain in self.brains:
                     if brain.hemi == hemi:
-                        brain.set_data(data['layer'], plot_data)
+                        brain.set_data(data['layer_id'], plot_data)
                 data["time_idx"] = time_idx
 
                 # Update time label
@@ -2775,7 +2776,7 @@ class _Hemisphere(object):
     @verbose
     def add_data(self, array, mlab_plot, vertices, smooth_mat, min, max,
                  thresh, lut, colormap, alpha, time, time_label, colorbar,
-                 layer):
+                 layer_id):
         """Add data to the brain"""
         # Calculate initial data to plot
         if array.ndim == 1:
@@ -2819,7 +2820,7 @@ class _Hemisphere(object):
         else:
             bar = None
 
-        self.data[layer] = {'array_id': array_id, 'pipeline': pipeline}
+        self.data[layer_id] = {'array_id': array_id, 'pipeline': pipeline}
 
         return surf, orig_ctable, bar
 
@@ -2913,14 +2914,14 @@ class _Hemisphere(object):
             return mlab.text(x, y, text, name=name, color=color,
                              opacity=opacity, figure=self._f)
 
-    def remove_data(self, layer):
+    def remove_data(self, layer_id):
         "Remove data shown with .add_data()"
-        data = self.data.pop(layer)
+        data = self.data.pop(layer_id)
         self._remove_scalar_data(data['array_id'])
 
-    def set_data(self, layer, values):
+    def set_data(self, layer_id, values):
         "Set displayed data"
-        data = self.data[layer]
+        data = self.data[layer_id]
         self._mesh_dataset.point_data.get_array(
             data['array_id']).from_array(values)
         data['pipeline'][-1].update()

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1781,13 +1781,9 @@ class Brain(object):
         self.surf = surf
         self._toggle_render(True, views)
 
-        if mlab.options.backend == 'test':
-            # required SetActiveAttribute filter attributes are not set under
-            # the testing backend
-            return
-
         for brain in self.brains:
-            brain._f.scene.reset_zoom()
+            if brain._f.scene is not None:
+                brain._f.scene.reset_zoom()
 
     @verbose
     def scale_data_colormap(self, fmin, fmid, fmax, transparent, verbose=None):

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -774,15 +774,6 @@ class Brain(object):
         return out
 
     @property
-    def _geo(self):
-        """Wrap to _geo"""
-        self._get_one_brain([[]], '_geo')
-        if ('lh' in self.geo) and ['lh'] is not None:
-            return self.geo['lh']
-        else:
-            return self.geo['rh']
-
-    @property
     def data(self):
         """Wrap to data"""
         self._get_one_brain([[]], 'data')
@@ -1934,7 +1925,6 @@ class Brain(object):
         -----
         Raises a RuntimeError if the Brain instance has not data overlay.
         """
-        time_idx = None
         for hemi in ['lh', 'rh']:
             data = self.data_dict[hemi]
             if data is not None:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1774,9 +1774,10 @@ class Brain(object):
                 self._toggle_render(True)
                 raise
 
-        # update mesh objects (the use a reference to geo.coords)
-        for brain in self.brains:
-            brain.update_surface()
+        # update mesh objects (they use a reference to geo.coords)
+        with mayavi_threshold_patch:
+            for brain in self.brains:
+                brain.update_surface()
 
         self.surf = surface
         self._toggle_render(True, views)

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1415,14 +1415,18 @@ class Brain(object):
                  "and will be removed in PySurfer 0.9", DeprecationWarning)
 
         if labels is None:
-            labels = self._label_dicts.keys()
-        elif isinstance(labels, str):
-            labels = [labels]
+            labels_ = self._label_dicts.keys()
+        else:
+            labels_ = [labels] if isinstance(labels, str) else labels
+            missing = [key for key in labels_ if key not in self._label_dicts]
+            if missing:
+                raise ValueError("labels=%r contains unknown labels: %s" %
+                                 (labels, ', '.join(map(repr, missing))))
 
-        for key in labels:
-            for data in self._label_dicts.pop(key):
-                for surf in data['surfaces']:
-                    surf.remove()
+        for key in labels_:
+            data = self._label_dicts.pop(key)
+            for surf in data['surfaces']:
+                surf.remove()
 
     def add_morphometry(self, measure, grayscale=False, hemi=None,
                         remove_existing=True, colormap=None,

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1699,10 +1699,10 @@ class Brain(object):
 
         Parameters
         ----------
-        view : {'lateral' | 'medial' | 'rostral' | 'caudal' |
-                'dorsal' | 'ventral' | 'frontal' | 'parietal' |
-                dict}
-            brain surface to view or kwargs to pass to mlab.view()
+        view : str | dict
+            brain surface to view (one of 'lateral', 'medial', 'rostral',
+            'caudal', 'dorsal', 'ventral', 'frontal', 'parietal') or kwargs to
+            pass to mlab.view()
 
         Returns
         -------
@@ -2275,25 +2275,25 @@ class Brain(object):
                             colorbar='auto', interpolation='quadratic'):
         """Save a temporal image sequence
 
-        The files saved are named "fname_pattern % (pos)" where "pos" is a
-        relative or absolute index (controlled by "use_abs_idx")
+        The files saved are named ``fname_pattern % pos`` where ``pos`` is a
+        relative or absolute index (controlled by ``use_abs_idx``).
 
         Parameters
         ----------
-        time_idx : array-like
+        time_idx : array_like
             Time indices to save. Non-integer values will be displayed using
             interpolation between samples.
         fname_pattern : str
             Filename pattern, e.g. 'movie-frame_%0.4d.png'.
-        use_abs_idx : boolean
-            If True the indices given by "time_idx" are used in the filename
+        use_abs_idx : bool
+            If True the indices given by ``time_idx`` are used in the filename
             if False the index in the filename starts at zero and is
             incremented by one for each image (Default: True).
         row : int
             Row index of the brain to use.
         col : int
             Column index of the brain to use.
-        montage: 'current' | 'single' | list
+        montage : 'current' | 'single' | list
             Views to include in the images: 'current' uses the currently
             displayed image; 'single' (default) uses a single view, specified
             by the ``row`` and ``col`` parameters; a 1 or 2 dimensional list
@@ -2301,13 +2301,13 @@ class Brain(object):
             ``['lat', 'med']`` lateral and ventral views ordered horizontally;
             ``[['fro'], ['ven']]`` frontal and ventral views ordered
             vertically.
-        border_size: int
+        border_size : int
             Size of image border (more or less space between images).
-        colorbar: 'auto' | int | list of int | None
+        colorbar : 'auto' | int | list of int | None
             For 'auto', the colorbar is shown in the middle view (default).
             For int or list of int, the colorbar is shown in the specified
             views. For ``None``, no colorbar is shown.
-       interpolation : str
+        interpolation : str
             Interpolation method (``scipy.interpolate.interp1d`` parameter,
             one of 'linear' | 'nearest' | 'zero' | 'slinear' | 'quadratic' |
             'cubic', default 'quadratic'). Interpolation is only used for
@@ -2315,8 +2315,8 @@ class Brain(object):
 
         Returns
         -------
-        images_written: list
-            all filenames written
+        images_written : list
+            All filenames written.
         """
         images_written = list()
         for i, idx in enumerate(self._iter_time(time_idx, interpolation)):


### PR DESCRIPTION
I often find myself plotting with one surface and then wanting to look at it with another. This implementation is based on keeping track of all the meshes that are added to the brain. I've implemented it for data, labels and annotations, not yet for all other layer types because I wanted to confirm first that there is no better way to implement it. I was wondering whether all the mesh objects could be combined into one somehow (re #177), but it looks like they all need to have a different `scalars` attribute, and I don't see a straightforward way to separate the scalars from the triangular mesh... 