### PR TITLE
FIX Brain.set_data_time_index():  skip data without time axis

### DIFF
--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -264,6 +264,11 @@ def test_meg_inverse():
     assert_equal(data_dicts[0]['time_idx'], 0)
     assert_equal(data_dicts[1]['time_idx'], 0)
 
+    # add second data-layer without time axis
+    brain.add_data(data[:, 1], colormap=colormap, vertices=vertices,
+                   smoothing_steps=2)
+    brain.set_data_time_index(2)
+
     # change surface
     brain.set_surf('white')
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1889,6 +1889,9 @@ class Brain(object):
         views = self._toggle_render(False)
         for hemi in ['lh', 'rh']:
             for data in self._data_dicts[hemi]:
+                if data['array'].ndim == 1:
+                    continue  # skip data without time axis
+
                 # interpolation
                 if isinstance(time_idx, float):
                     times = np.arange(self.n_times)


### PR DESCRIPTION
Fix for a corner case where multiple data layers are added, and not all of them have a time axis