### PR TITLE
MRG+1: allowing transparency in divergent colormaps

### DIFF
--- a/examples/plot_meg_inverse_solution.py
+++ b/examples/plot_meg_inverse_solution.py
@@ -23,7 +23,7 @@ hemi = 'lh'
 create Brain object for visualization
 """
 brain = Brain(subject_id, hemi, surf, size=(400, 400),
-              interaction='terrain')
+              interaction='terrain', cortex='bone')
 
 """
 label for time annotation in milliseconds

--- a/examples/plot_resting_correlations.py
+++ b/examples/plot_resting_correlations.py
@@ -46,14 +46,18 @@ for overlay in brain.overlays_dict["ang_corr_rh"]:
 We want to use an appropriate color map for these data: a divergent map that
 is centered on 0, which is a meaningful transition-point as it marks the change
 from negative correlations to positive correlations.
-
-We'll also plot the map with some transparency so that we can see through to
-the underlying anatomy.
 """
-brain.add_data(surf_data_lh, -.7, .7, colormap="vlag", alpha=.75,
-               hemi='lh')
-brain.add_data(surf_data_rh, -.7, .7, colormap="vlag", alpha=.75,
-               hemi='rh')
+brain.add_data(surf_data_lh, -.7, .7, colormap="vlag", hemi='lh')
+brain.add_data(surf_data_rh, -.7, .7, colormap="vlag", hemi='rh')
+
+"""
+You can make the small correlations transparent by re-scaling the colormap with
+transparency and letting the rescaler know that this is a divergent color map.
+In this case the first number gives the value that should be in the center of
+the colormap, the second determines which values will be transparent and the 
+third determines the left and right edges of the new colormap.
+"""
+brain.scale_data_colormap(0, .35, .7, transparent=True, divergent=True)
 
 """
 This overlay represents resting-state correlations with a

--- a/examples/plot_resting_correlations.py
+++ b/examples/plot_resting_correlations.py
@@ -60,6 +60,13 @@ third determines the left and right edges of the new colormap.
 brain.scale_data_colormap(0, .35, .7, transparent=True, divergent=True)
 
 """
+You can also set the overall opacity of the displayed data while maintaining
+the transparency of the small values.
+"""
+brain.scale_data_colormap(0, .35, .7, transparent=True, divergent=True, 
+                          alpha=0.75)
+
+"""
 This overlay represents resting-state correlations with a
 seed in left angular gyrus. Let's plot that seed.
 """

--- a/examples/plot_resting_correlations.py
+++ b/examples/plot_resting_correlations.py
@@ -55,7 +55,7 @@ brain.add_data(surf_data_rh, 0, .7, center=0, hemi='rh')
 You can tune the data display by shifting the colormap around interesting
 regions. For example, you can ignore small correlation up to a magnitude of 0.2
 and let colors become gradually less transparent from 0.2 to 0.5 by re-scaling
-the colormap as follows. For more information see the help string of this 
+the colormap as follows. For more information see the help string of this
 function.
 """
 brain.scale_data_colormap(.2, .5, .7, transparent=True, center=0)
@@ -64,7 +64,7 @@ brain.scale_data_colormap(.2, .5, .7, transparent=True, center=0)
 You can also set the overall opacity of the displayed data while maintaining
 the transparency of the small values.
 """
-brain.scale_data_colormap(0, .35, .7, transparent=True, center=0, 
+brain.scale_data_colormap(0, .35, .7, transparent=True, center=0,
                           alpha=0.75)
 
 """

--- a/examples/plot_resting_correlations.py
+++ b/examples/plot_resting_correlations.py
@@ -45,25 +45,26 @@ for overlay in brain.overlays_dict["ang_corr_rh"]:
 """
 We want to use an appropriate color map for these data: a divergent map that
 is centered on 0, which is a meaningful transition-point as it marks the change
-from negative correlations to positive correlations.
+from negative correlations to positive correlations. By providing the 'center'
+argument the add_data function automatically chooses a divergent colormap.
 """
-brain.add_data(surf_data_lh, -.7, .7, colormap="vlag", hemi='lh')
-brain.add_data(surf_data_rh, -.7, .7, colormap="vlag", hemi='rh')
+brain.add_data(surf_data_lh, 0, .7, center=0, hemi='lh')
+brain.add_data(surf_data_rh, 0, .7, center=0, hemi='rh')
 
 """
-You can make the small correlations transparent by re-scaling the colormap with
-transparency and letting the rescaler know that this is a divergent color map.
-In this case the first number gives the value that should be in the center of
-the colormap, the second determines which values will be transparent and the 
-third determines the left and right edges of the new colormap.
+You can tune the data display by shifting the colormap around interesting
+regions. For example, you can ignore small correlation up to a magnitude of 0.2
+and let colors become gradually less transparent from 0.2 to 0.5 by re-scaling
+the colormap as follows. For more information see the help string of this 
+function.
 """
-brain.scale_data_colormap(0, .35, .7, transparent=True, divergent=True)
+brain.scale_data_colormap(.2, .5, .7, transparent=True, center=0)
 
 """
 You can also set the overall opacity of the displayed data while maintaining
 the transparency of the small values.
 """
-brain.scale_data_colormap(0, .35, .7, transparent=True, divergent=True, 
+brain.scale_data_colormap(0, .35, .7, transparent=True, center=0, 
                           alpha=0.75)
 
 """

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -482,6 +482,7 @@ def create_color_lut(cmap, n_colors=256, center=None):
     center : double, optional
         indicates whether desired colormap should be for divergent values, 
         currently only used to select default colormap for cmap='auto'
+        
     Returns
     -------
     lut : n_colors x 4 integer array
@@ -499,7 +500,7 @@ def create_color_lut(cmap, n_colors=256, center=None):
 
             return lut
 
-    if isinstance(cmap, string_types) and cmap=="auto":
+    if isinstance(cmap, string_types) and cmap == "auto":
         if center is None:
             cmap = "rocket"
         else:

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -500,6 +500,8 @@ def create_color_lut(cmap, n_colors=256, center=None):
 
             return lut
 
+    # choose default colormaps (REMEMBER to change doc, e.g., in 
+    # Brain.add_data, when changing these defaults)
     if isinstance(cmap, string_types) and cmap == "auto":
         if center is None:
             cmap = "rocket"

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -464,7 +464,7 @@ def mesh_edges(faces):
     return edges
 
 
-def create_color_lut(cmap, n_colors=256):
+def create_color_lut(cmap, n_colors=256, center=None):
     """Return a colormap suitable for setting as a Mayavi LUT.
 
     Parameters
@@ -473,9 +473,15 @@ def create_color_lut(cmap, n_colors=256):
         Input colormap definition. This can be the name of a matplotlib
         colormap, a list of valid matplotlib colors, or a suitable
         mayavi LUT (possibly missing the alpha channel).
+        
+        if value is "auto", a default sequential or divergent colormap is 
+        returned
     n_colors : int, optional
         Number of colors in the resulting LUT. This is ignored if cmap
         is a 2d array.
+    center : double, optional
+        indicates whether desired colormap should be for divergent values, 
+        currently only used to select default colormap for cmap='auto'
     Returns
     -------
     lut : n_colors x 4 integer array
@@ -492,6 +498,12 @@ def create_color_lut(cmap, n_colors=256):
                 lut = np.c_[cmap, alpha]
 
             return lut
+
+    if isinstance(cmap, string_types) and cmap=="auto":
+        if center is None:
+            cmap = "rocket"
+        else:
+            cmap = "icefire"
 
     surfer_cmaps = ["rocket", "mako", "icefire", "vlag"]
     surfer_cmaps += [name + "_r" for name in surfer_cmaps]

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -473,16 +473,16 @@ def create_color_lut(cmap, n_colors=256, center=None):
         Input colormap definition. This can be the name of a matplotlib
         colormap, a list of valid matplotlib colors, or a suitable
         mayavi LUT (possibly missing the alpha channel).
-        
-        if value is "auto", a default sequential or divergent colormap is 
+
+        if value is "auto", a default sequential or divergent colormap is
         returned
     n_colors : int, optional
         Number of colors in the resulting LUT. This is ignored if cmap
         is a 2d array.
     center : double, optional
-        indicates whether desired colormap should be for divergent values, 
+        indicates whether desired colormap should be for divergent values,
         currently only used to select default colormap for cmap='auto'
-        
+
     Returns
     -------
     lut : n_colors x 4 integer array
@@ -500,7 +500,7 @@ def create_color_lut(cmap, n_colors=256, center=None):
 
             return lut
 
-    # choose default colormaps (REMEMBER to change doc, e.g., in 
+    # choose default colormaps (REMEMBER to change doc, e.g., in
     # Brain.add_data, when changing these defaults)
     if isinstance(cmap, string_types) and cmap == "auto":
         if center is None:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -959,15 +959,14 @@ class Brain(object):
         self.overlays_dict[name] = ol
         self._toggle_render(True, views)
 
-    	@verbose
-		def add_data(self, array, min=None, max=None, mid=None, 
-                 thresh=None, center=None, transparent=False, 
+    @verbose
+	def add_data(self, array, min=None, max=None, thresh=None, 
                  colormap="auto", alpha=1,
                  vertices=None, smoothing_steps=20, time=None,
                  time_label="time index=%d", colorbar=True,
                  hemi=None, remove_existing=False, time_label_size=14,
-                 initial_time=None, scale_factor=None, vector_alpha=None,
-                 verbose=None):
+                 initial_time=None, scale_factor=None, vector_alpha=None, 
+                 mid=None, center=None, transparent=False, verbose=None):
         """Display data from a numpy array on the surface.
 
         This provides a similar interface to
@@ -992,10 +991,10 @@ class Brain(object):
             and pass ``time_label=None``.
         min : float
             min value in colormap (uses real min if None)
-        max : float
-            max value in colormap (uses real max if None)
         mid : float
             intermediate value in colormap (middle between min and max if None)
+        max : float
+            max value in colormap (uses real max if None)
         thresh : None or float
             if not None, values below thresh will not be visible
         center : float or None
@@ -1008,8 +1007,8 @@ class Brain(object):
             name of matplotlib colormap to use, a list of matplotlib colors,
             or a custom look up table (an n x 4 array coded with RBGA values
             between 0 and 255), the default "auto" chooses a default divergent 
-            colormap, if "center" is given, otherwise a default sequential 
-            colormap.
+            colormap, if "center" is given (currently "icefire"), otherwise a 
+            default sequential colormap (currently "rocket").
         alpha : float in [0, 1]
             alpha level to control opacity of the overlay.
         vertices : numpy array
@@ -1042,8 +1041,6 @@ class Brain(object):
         vector_alpha : float | None
             alpha level to control opacity of the arrows. Only used for
             vector-valued data. If None (default), ``alpha`` is used.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see surfer.verbose).
 
         Notes
         -----
@@ -1866,13 +1863,13 @@ class Brain(object):
         divergent indicate this by providing a value for 'center'. The 
         meanings of fmin, fmid and fmax are different for sequential and 
         divergent colormaps. For sequential colormaps the colormap is 
-        characterised by:
+        characterised by::
             
             [fmin, fmid, fmax]
         
         where fmin and fmax define the edges of the colormap and fmid will be
         the value mapped to the center of the originally chosen colormap. For
-        divergent colormaps the colormap is characterised by
+        divergent colormaps the colormap is characterised by::
             
             [center-fmax, center-fmid, center-fmin, center, 
              center+fmin, center+fmid, center+fmax]
@@ -1890,8 +1887,8 @@ class Brain(object):
         fmax : float
             maximum value for colormap
         transparent : boolean
-            if True: use a linear transparency between fmin and fmid, or 
-            between center-fmin to center-fmid and center+fmin to center+fmid
+            if True: use a linear transparency between fmin and fmid
+            (symmetrically for divergent colormaps)
         center : float
             if not None, gives the data value that should be mapped to the 
             center of the (divergent) colormap
@@ -2761,7 +2758,7 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
     """
     if not (fmin < fmid) and (fmid < fmax):
         raise ValueError("Invalid colormap, we need fmin<fmid<fmax")
-    if not (alpha >= 0) and (alpha <= 1):
+    if not 0 <= alpha <= 1:
         raise ValueError("Invalid alpha: it needs to be within [0, 1]")
 
     # Cast inputs to float to prevent integer division

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -999,7 +999,7 @@ class Brain(object):
             if not None, values below thresh will not be visible
         center : float or None
             if not None, center of a divergent colormap, changes the meaning of
-            min, max and mid, see ``scale_data_colormap`` for further info
+            min, max and mid, see :meth:`scale_data_colormap` for further info.
         transparent : bool
             if True: use a linear transparency between fmin and fmid and make
             values below fmin fully transparent (symmetrically for divergent 
@@ -1944,6 +1944,17 @@ class Brain(object):
                         else:
                             l_m.data_range = np.array([fmin, fmax])
                 
+                # Update the colorbar to deal with transparency
+                cbar_lut = tvtk.LookupTable()
+                cbar_lut.deep_copy(surf.module_manager.scalar_lut_manager.lut)
+                vals = lut / 255.
+                alphas = vals[:, -1][:, np.newaxis]
+                vals = (vals * alphas) + 0.5 * (1 - alphas)
+                vals[:, -1] = 1.
+                for ii in range(256):
+                    cbar_lut.set_table_value(ii, vals[ii])
+                surf.module_manager.scalar_lut_manager.scalar_bar.lookup_table = cbar_lut  # noqa
+
         self._toggle_render(True, views)
 
     def set_data_time_index(self, time_idx, interpolation='quadratic'):

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -960,7 +960,7 @@ class Brain(object):
         self._toggle_render(True, views)
 
     @verbose
-	def add_data(self, array, min=None, max=None, thresh=None, 
+    def add_data(self, array, min=None, max=None, thresh=None, 
                  colormap="auto", alpha=1,
                  vertices=None, smoothing_steps=20, time=None,
                  time_label="time index=%d", colorbar=True,

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2723,9 +2723,10 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
                 "transparent=%d divergent=%d" % (fmin, fmid, fmax, transparent,
                                                  divergent))
 
+    n_colors = lut_table.shape[0]
+
     # Add transparency if needed
     if transparent:
-        n_colors = lut_table.shape[0]
         if divergent:
             N4 = np.full(4, n_colors / 4, dtype=int)
             N4[:np.mod(n_colors, 4)] += 1

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -960,12 +960,12 @@ class Brain(object):
         self._toggle_render(True, views)
 
     @verbose
-    def add_data(self, array, min=None, max=None, thresh=None, 
+    def add_data(self, array, min=None, max=None, thresh=None,
                  colormap="auto", alpha=1,
                  vertices=None, smoothing_steps=20, time=None,
                  time_label="time index=%d", colorbar=True,
                  hemi=None, remove_existing=False, time_label_size=14,
-                 initial_time=None, scale_factor=None, vector_alpha=None, 
+                 initial_time=None, scale_factor=None, vector_alpha=None,
                  mid=None, center=None, transparent=False, verbose=None):
         """Display data from a numpy array on the surface.
 
@@ -1002,13 +1002,13 @@ class Brain(object):
             min, max and mid, see :meth:`scale_data_colormap` for further info.
         transparent : bool
             if True: use a linear transparency between fmin and fmid and make
-            values below fmin fully transparent (symmetrically for divergent 
+            values below fmin fully transparent (symmetrically for divergent
             colormaps)
         colormap : string, list of colors, or array
             name of matplotlib colormap to use, a list of matplotlib colors,
             or a custom look up table (an n x 4 array coded with RBGA values
-            between 0 and 255), the default "auto" chooses a default divergent 
-            colormap, if "center" is given (currently "icefire"), otherwise a 
+            between 0 and 255), the default "auto" chooses a default divergent
+            colormap, if "center" is given (currently "icefire"), otherwise a
             default sequential colormap (currently "rocket").
         alpha : float in [0, 1]
             alpha level to control opacity of the overlay.
@@ -1113,7 +1113,7 @@ class Brain(object):
             layer_id = 0
 
         data = dict(array=array, smoothing_steps=smoothing_steps,
-                    fmin=min, fmid=mid, fmax=max, center=center, 
+                    fmin=min, fmid=mid, fmax=max, center=center,
                     scale_factor=scale_factor,
                     transparent=False, time=0, time_idx=0,
                     vertices=vertices, smooth_mat=smooth_mat,
@@ -1187,7 +1187,7 @@ class Brain(object):
         data['colorbars'] = bars
         data['orig_ctable'] = ct
         data['glyphs'] = glyphs
-        
+
         self._data_dicts[hemi].append(data)
 
         self.scale_data_colormap(min, mid, max, transparent, center, alpha)
@@ -1856,27 +1856,27 @@ class Brain(object):
                 brain._f.scene.reset_zoom()
 
     @verbose
-    def scale_data_colormap(self, fmin, fmid, fmax, transparent, 
+    def scale_data_colormap(self, fmin, fmid, fmax, transparent,
                             center=None, alpha=1.0, verbose=None):
         """Scale the data colormap.
-        
-        The colormap may be sequential or divergent. When the colormap is 
-        divergent indicate this by providing a value for 'center'. The 
-        meanings of fmin, fmid and fmax are different for sequential and 
-        divergent colormaps. For sequential colormaps the colormap is 
+
+        The colormap may be sequential or divergent. When the colormap is
+        divergent indicate this by providing a value for 'center'. The
+        meanings of fmin, fmid and fmax are different for sequential and
+        divergent colormaps. For sequential colormaps the colormap is
         characterised by::
-            
+
             [fmin, fmid, fmax]
-        
+
         where fmin and fmax define the edges of the colormap and fmid will be
         the value mapped to the center of the originally chosen colormap. For
         divergent colormaps the colormap is characterised by::
-            
-            [center-fmax, center-fmid, center-fmin, center, 
+
+            [center-fmax, center-fmid, center-fmin, center,
              center+fmin, center+fmid, center+fmax]
-        
-        i.e., values between center-fmin and center+fmin will not be shown 
-        while center-fmid will map to the middle of the first half of the 
+
+        i.e., values between center-fmin and center+fmin will not be shown
+        while center-fmid will map to the middle of the first half of the
         original colormap and center-fmid to the middle of the second half.
 
         Parameters
@@ -1889,10 +1889,10 @@ class Brain(object):
             maximum value for colormap
         transparent : boolean
             if True: use a linear transparency between fmin and fmid and make
-            values below fmin fully transparent (symmetrically for divergent 
+            values below fmin fully transparent (symmetrically for divergent
             colormaps)
         center : float
-            if not None, gives the data value that should be mapped to the 
+            if not None, gives the data value that should be mapped to the
             center of the (divergent) colormap
         alpha : float
             sets the overall opacity of colors, maintains transparent regions
@@ -1908,7 +1908,7 @@ class Brain(object):
                 table = data["orig_ctable"].copy()
                 break
 
-        lut = _scale_mayavi_lut(table, fmin, fmid, fmax, transparent, 
+        lut = _scale_mayavi_lut(table, fmin, fmid, fmax, transparent,
                                 center, alpha)
 
         views = self._toggle_render(False)
@@ -1923,7 +1923,7 @@ class Brain(object):
                         cmap.data_range = np.array([center-fmax, center+fmax])
                     else:
                         cmap.data_range = np.array([fmin, fmax])
-                        
+
                     # handle transparency of colorbar
                     if transparent:
                         cmap.scalar_bar.use_opacity = 1
@@ -1943,7 +1943,7 @@ class Brain(object):
                                     [center-fmax, center+fmax])
                         else:
                             l_m.data_range = np.array([fmin, fmax])
-                
+
                 # Update the colorbar to deal with transparency
                 cbar_lut = tvtk.LookupTable()
                 cbar_lut.deep_copy(surf.module_manager.scalar_lut_manager.lut)
@@ -1953,7 +1953,7 @@ class Brain(object):
                 vals[:, -1] = 1.
                 for ii in range(256):
                     cbar_lut.set_table_value(ii, vals[ii])
-                surf.module_manager.scalar_lut_manager.scalar_bar.lookup_table = cbar_lut  # noqa
+                surf.module_manager.scalar_lut_manager.scalar_bar.lookup_table = cbar_lut  # noqa: E501
 
         self._toggle_render(True, views)
 
@@ -2711,7 +2711,7 @@ class Brain(object):
 
 def _scale_sequential_lut(lut_table, fmin, fmid, fmax):
     """Scale a sequential colormap."""
-    
+
     lut_table_new = lut_table.copy()
     n_colors = lut_table.shape[0]
     n_colors2 = n_colors // 2
@@ -2722,8 +2722,8 @@ def _scale_sequential_lut(lut_table, fmin, fmid, fmax):
                                         (fmax - fmin))) - 1)
 
     # morph each color channel so that fmid gets assigned the middle color of
-    # the original table and the number of colors to the left and right are 
-    # stretched or squeezed such that they correspond to the distance of fmid 
+    # the original table and the number of colors to the left and right are
+    # stretched or squeezed such that they correspond to the distance of fmid
     # to fmin and fmax, respectively
     for i in range(4):
         part1 = np.interp(np.linspace(0, n_colors2 - 1, fmid_idx + 1),
@@ -2741,16 +2741,16 @@ def _scale_sequential_lut(lut_table, fmin, fmid, fmax):
 
 def _get_fill_colors(cols, n_fill):
     """Get the fill colors for the middle of divergent colormaps.
-    
+
     Tries to figure out whether there is a smooth transition in the center of
-    the original colormap. If yes, it chooses the color in the center as the 
+    the original colormap. If yes, it chooses the color in the center as the
     only fill color, else it chooses the two colors between which there is
     a large step in color space to fill up the middle of the new colormap.
     """
     steps = np.linalg.norm(np.diff(cols[:, :3].astype(float), axis=0), axis=1)
-    
+
     # if there is a jump in the middle of the colors
-    # (define a jump as a step in 3D colorspace whose size is 3-times larger 
+    # (define a jump as a step in 3D colorspace whose size is 3-times larger
     # than the mean step size between the first and last steps of the given
     # colors - I verified that no such jumps exist in the divergent colormaps
     # of matplotlib 2.0 which all have a smooth transition in the middle)
@@ -2763,7 +2763,7 @@ def _get_fill_colors(cols, n_fill):
     else:
         # choose a color from the middle of the colormap
         fillcols = np.tile(cols[int(cols.shape[0] / 2), :], (n_fill, 1))
-        
+
     return fillcols
 
 
@@ -2775,8 +2775,8 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
     This function operates on a Mayavi LUTManager. This manager can be obtained
     through the traits interface of mayavi. For example:
     ``x.module_manager.vector_lut_manager``.
-    
-    Divergent colormaps are respected, if ``center`` is given, see 
+
+    Divergent colormaps are respected, if ``center`` is given, see
     ``Brain.scale_data_colormap`` for more info.
 
     Parameters
@@ -2791,10 +2791,10 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
         maximum value for colormap.
     transparent : boolean
         if True: use a linear transparency between fmin and fmid and make
-        values below fmin fully transparent (symmetrically for divergent 
+        values below fmin fully transparent (symmetrically for divergent
         colormaps)
     center : float
-        gives the data value that should be mapped to the center of the 
+        gives the data value that should be mapped to the center of the
         (divergent) colormap
     alpha : float
         sets the overall opacity of colors, maintains transparent regions
@@ -2820,10 +2820,11 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
 
     trstr = ['(opaque)', '(transparent)']
     if divergent:
-        logger.info("colormap divergent: center=%0.2e, [%0.2e, %0.2e, %0.2e] %s"
-                    % (center, fmin, fmid, fmax, trstr[transparent]))
+        logger.info(
+            "colormap divergent: center=%0.2e, [%0.2e, %0.2e, %0.2e] %s"
+            % (center, fmin, fmid, fmax, trstr[transparent]))
     else:
-        logger.info("colormap sequential: [%0.2e, %0.2e, %0.2e] %s" 
+        logger.info("colormap sequential: [%0.2e, %0.2e, %0.2e] %s"
                     % (fmin, fmid, fmax, trstr[transparent]))
 
     n_colors = lut_table.shape[0]
@@ -2834,9 +2835,9 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
             N4 = np.full(4, n_colors / 4, dtype=int)
             N4[:np.mod(n_colors, 4)] += 1
             assert N4.sum() == n_colors
-            lut_table[:, -1] = np.r_[255 * np.ones(N4[0]), 
+            lut_table[:, -1] = np.r_[255 * np.ones(N4[0]),
                                      np.linspace(255, 0, N4[2]),
-                                     np.linspace(0, 255, N4[3]), 
+                                     np.linspace(0, 255, N4[3]),
                                      255 * np.ones(N4[1])]
         else:
             n_colors2 = int(n_colors / 2)
@@ -2850,24 +2851,24 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
     if divergent:
         # the colormap should consist of 3 parts: a left part for the negative
         # data, a right part for the positive data and a middle, fill part
-        # representing the values in [center-fmin, center+fmin], we 
-        # introduce this middle part by extending the number of 'colors' of the 
+        # representing the values in [center-fmin, center+fmin], we
+        # introduce this middle part by extending the number of 'colors' of the
         # original colormap because the Mayavi lut manager scales linearly
-        # between colors and we don't want to reduce the color resolution in 
+        # between colors and we don't want to reduce the color resolution in
         # the interesting regions of data space
         n_colors2 = int(n_colors / 2)
         n_fill = int(round(fmin * n_colors2 / (fmax-fmin))) * 2
         lut_table = np.r_[
-                _scale_sequential_lut(lut_table[:n_colors2, :], 
-                                      center-fmax, center-fmid, center-fmin), 
+                _scale_sequential_lut(lut_table[:n_colors2, :],
+                                      center-fmax, center-fmid, center-fmin),
                 _get_fill_colors(
-                        lut_table[n_colors2 - 3 : n_colors2 + 3, :], n_fill),
-                _scale_sequential_lut(lut_table[n_colors2:, :], 
+                    lut_table[n_colors2 - 3:n_colors2 + 3, :], n_fill),
+                _scale_sequential_lut(lut_table[n_colors2:, :],
                                       center+fmin, center+fmid, center+fmax)]
     else:
         lut_table = _scale_sequential_lut(lut_table, fmin, fmid, fmax)
-        
-    # rescale to 256 colors; this is necessary, because Mayavi/VTK does not 
+
+    # rescale to 256 colors; this is necessary, because Mayavi/VTK does not
     # handle a change in the number of colors well: when you change from a long
     # table to a short table, values beyond the table value range get somehow
     # not mapped to the colors defined by the table edges; it may be that this
@@ -2879,11 +2880,11 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
         lut = np.zeros((256, 4))
         x = np.linspace(1, n_colors, 256)
         for chan in range(4):
-            lut[:, chan] = np.interp(x, 
+            lut[:, chan] = np.interp(x,
                                      np.arange(1, n_colors+1),
                                      lut_table[:, chan])
         lut_table = lut
-        
+
     return lut_table
 
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1945,14 +1945,15 @@ class Brain(object):
                             l_m.data_range = np.array([fmin, fmax])
 
                 # Update the colorbar to deal with transparency
+                bgcolor = np.mean(self._brain_list[0]['brain']._geo_surf
+                                  .module_manager.scalar_lut_manager
+                                  .lut.table.to_array(), axis=0)
                 cbar_lut = tvtk.LookupTable()
                 cbar_lut.deep_copy(surf.module_manager.scalar_lut_manager.lut)
-                vals = lut / 255.
-                alphas = vals[:, -1][:, np.newaxis]
-                vals = (vals * alphas) + 0.5 * (1 - alphas)
-                vals[:, -1] = 1.
-                for ii in range(256):
-                    cbar_lut.set_table_value(ii, vals[ii])
+                alphas = lut[:, -1][:, np.newaxis] / 255.
+                vals = (lut * alphas) + bgcolor * (1 - alphas)
+                vals[:, -1] = 255.
+                cbar_lut.table.from_array(vals)
                 surf.module_manager.scalar_lut_manager.scalar_bar.lookup_table = cbar_lut  # noqa: E501
 
         self._toggle_render(True, views)

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1042,6 +1042,8 @@ class Brain(object):
         vector_alpha : float | None
             alpha level to control opacity of the arrows. Only used for
             vector-valued data. If None (default), ``alpha`` is used.
+        verbose : bool, str, int, or None
+            If not None, override default verbose level (see surfer.verbose).
 
         Notes
         -----
@@ -1208,7 +1210,7 @@ class Brain(object):
             hemisphere, i.e. ``annot=(labels, ctab)`` for a single hemisphere
             or ``annot=((lh_labels, lh_ctab), (rh_labels, rh_ctab))`` for both
             hemispheres. ``labels`` and ``ctab`` should be arrays as returned
-            by :func:`nibabel.freesurfer.read_annot`.
+            by :func:`nibabel.freesurfer.io.read_annot`.
         borders : bool | int
             Show only label borders. If int, specify the number of steps
             (away from the true border) along the cortical mesh to include

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2807,14 +2807,13 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
 
     divergent = center is not None
 
+    trstr = ['(opaque)', '(transparent)']
     if divergent:
-        logger.info("colormap: fmin=%0.2e fmid=%0.2e fmax=%0.2e "
-                    "transparent=%d center=%d" % (fmin, fmid, fmax, transparent,
-                                                  center))
+        logger.info("colormap divergent: center=%0.2e, [%0.2e, %0.2e, %0.2e] %s"
+                    % (center, fmin, fmid, fmax, trstr[transparent]))
     else:
-        logger.info("colormap: fmin=%0.2e fmid=%0.2e fmax=%0.2e "
-                    "transparent=%d center=None" % (fmin, fmid, fmax, 
-                                                    transparent))
+        logger.info("colormap sequential: [%0.2e, %0.2e, %0.2e] %s" 
+                    % (fmin, fmid, fmax, trstr[transparent]))
 
     n_colors = lut_table.shape[0]
 


### PR DESCRIPTION
When analysing some of my data I came across the issue that I couldn't use a divergent colormap for, e.g., correlations or t-values and at the same time let small values in the middle of the colormap be transparent. So I have adapted Brain.scale_data_colormap such that it can now handle transparency in divergent colormaps properly. Also, I added the option to set the overall alpha-level of the colormap while maintaining transparency of a particular region in the colormap. The usage of these features is demonstrated in examples/plot_resting_correlations.py.

I believe that these changes make it easier to explore suitable visualisations of divergent data and hope that you find them useful!