### PR TITLE
Fix annotation colors

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1264,8 +1264,9 @@ class Brain(object):
                 cmap = np.vstack((cmap, np.zeros(5, int)))
 
             # Set label ids sensibly
-            ord = np.argsort(cmap[:, -1])
-            ids = ord[np.searchsorted(cmap[ord, -1], labels)]
+            order = np.argsort(cmap[:, -1])
+            cmap = cmap[order]
+            ids = np.searchsorted(cmap[:, -1], labels)
             cmap = cmap[:, :4]
 
             #  Set the alpha level
@@ -3014,6 +3015,7 @@ class _Hemisphere(object):
     def add_annotation(self, annot, ids, cmap):
         """Add an annotation file"""
         # Add scalar values to dataset
+        print(ids)
         array_id, pipe = self._add_scalar_data(ids)
         with warnings.catch_warnings(record=True):
             surf = mlab.pipeline.surface(pipe, name=annot, figure=self._f)

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -3015,7 +3015,6 @@ class _Hemisphere(object):
     def add_annotation(self, annot, ids, cmap):
         """Add an annotation file"""
         # Add scalar values to dataset
-        print(ids)
         array_id, pipe = self._add_scalar_data(ids)
         with warnings.catch_warnings(record=True):
             surf = mlab.pipeline.surface(pipe, name=annot, figure=self._f)


### PR DESCRIPTION
When annotating the brain with a brain atlas, the colors are not always set right:

```python
import surfer
brain = surfer.Brain('fsaverage', hemi='both', surf='inflated')
brain.add_annotation('aparc', borders=False)
```
![fig1](https://user-images.githubusercontent.com/428273/31120297-99792860-a83c-11e7-9e03-51dc456d7d56.png)

This has to do with the reordering of `cmap` and the translation of the `ids` vector. This PR fixes it:

![fig2](https://user-images.githubusercontent.com/428273/31120304-9f2cfa98-a83c-11e7-9f37-f7adbb1fee11.png)
