### PR TITLE
FIX: Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ if __name__ == "__main__":
           platforms='any',
           packages=['surfer', 'surfer.tests'],
           scripts=['bin/pysurfer'],
-          install_requires=['nibabel >= 1.2'],
+          install_requires=['nibabel >= 1.2', 'mayavi'],
           extras_require={'save_movie': ['imageio >= 1.5']},
           )

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,8 @@ VERSION = version
 
 
 def check_dependencies():
-    needed_deps = ["numpy", "scipy", "matplotlib",
-                   "mayavi",
-                   ]
+    # nibabel and mayavi are in install_requires
+    needed_deps = ["numpy", "scipy", "matplotlib"]
     missing_deps = []
     for dep in needed_deps:
         try:


### PR DESCRIPTION
When trying to set up an Anaconda environment using `pip` to simultaneously install `mayavi` and `PySurfer`, I get these errors:
```
Installing collected packages: mne, nibabel, imageio, pysurfer, nitime, nilearn, quantities, neo, termcolor, pytest-sugar, pytest-faulthandler, pydocstyle, sphinx-bootstrap-theme, traits, pyface, traitsui, configobj, apptools, mayavi, sphinx-gallery
  Running setup.py install for pysurfer ... error
    Complete output from command /home/larsoner/anaconda2/envs/mne/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-45nhe837/pysurfer/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-3smloy5u-record/install-record.txt --single-version-externally-managed --compile:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-45nhe837/pysurfer/setup.py", line 64, in <module>
        check_dependencies()
      File "/tmp/pip-build-45nhe837/pysurfer/setup.py", line 51, in check_dependencies
        raise ImportError("Missing dependencies: %s" % missing)
    ImportError: Missing dependencies: mayavi
```
This is because we don't tell `pip` about the `mayavi` dependency, so it tries to install `PySurfer` first. We should either remove our custom dependency check, or add `mayavi` to the deps list -- this PR does the latter.