### PR TITLE
BUG: Add 'center' as a data property

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -691,7 +691,7 @@ class Brain(object):
         """
         props = dict()
         keys = ['fmin', 'fmid', 'fmax', 'transparent', 'time', 'time_idx',
-                'smoothing_steps']
+                'smoothing_steps', 'center']
         try:
             if self.data_dict['lh'] is not None:
                 hemi = 'lh'


### PR DESCRIPTION
Fixes an error I get when opening a `TimeViewer` complaining about `'center'` missing from the data properties dict.