### PR TITLE
MRG: Add units kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ pysurfer.egg-info
 examples/example_data/coord-lh.label
 .ipynb_checkpoints/
 .cache/
+.pytest_cache/

--- a/examples/plot_label_foci.py
+++ b/examples/plot_label_foci.py
@@ -16,7 +16,8 @@ subject_id = "fsaverage"
 """
 Bring up the visualization.
 """
-brain = Brain(subject_id, "lh", "inflated", cortex=("gray", -2, 7, True))
+brain = Brain(subject_id, "lh", "inflated", cortex=("gray", -2, 7, True),
+              units='m')
 
 """
 First we'll identify a stereotaxic focus in the MNI coordinate system. This
@@ -62,4 +63,4 @@ brain.add_foci([coord], map_surface="white", coords_as_verts=True,
 """
 Set the camera position to show the extent of the labels.
 """
-brain.show_view(dict(elevation=40, distance=430))
+brain.show_view(dict(elevation=40, distance=0.430))

--- a/examples/plot_meg_inverse_solution.py
+++ b/examples/plot_meg_inverse_solution.py
@@ -13,72 +13,60 @@ from surfer.io import read_stc
 
 print(__doc__)
 
-"""
-define subject, surface and hemisphere(s) to plot
-"""
+###############################################################################
+# Set up some useful variables
+
+# define subject, surface and hemisphere(s) to plot:
+
 subject_id, surf = 'fsaverage', 'inflated'
 hemi = 'lh'
 
-"""
-create Brain object for visualization
-"""
+# create Brain object for visualization
 brain = Brain(subject_id, hemi, surf, size=(400, 400), background='w',
-              interaction='terrain', cortex='bone')
+              interaction='terrain', cortex='bone', units='m')
 
-"""
-label for time annotation in milliseconds
-"""
+# label for time annotation in milliseconds
 
 
 def time_label(t):
     return 'time=%0.2f ms' % (t * 1e3)
 
 
-"""
-read MNE dSPM inverse solution
-"""
+###############################################################################
+# Read MNE dSPM inverse solution and plot
+
 for hemi in ['lh']:  # , 'rh']:
     stc_fname = os.path.join('example_data', 'meg_source_estimate-' +
                              hemi + '.stc')
     stc = read_stc(stc_fname)
 
-    """
-    data and vertices for which the data is defined
-    """
+    # data and vertices for which the data is defined
     data = stc['data']
     vertices = stc['vertices']
 
-    """
-    time points (in seconds)
-    """
+    # time points (in seconds)
     time = np.linspace(stc['tmin'], stc['tmin'] + data.shape[1] * stc['tstep'],
                        data.shape[1], endpoint=False)
 
-    """
-    colormap to use
-    """
+    # colormap to use
     colormap = 'hot'
 
-    """
-    add data and set the initial time displayed to 100 ms
-    """
+    # add data and set the initial time displayed to 100 ms
     brain.add_data(data, colormap=colormap, vertices=vertices,
                    smoothing_steps=5, time=time, time_label=time_label,
                    hemi=hemi, initial_time=0.1, verbose=False)
 
-"""
-scale colormap
-"""
+# scale colormap
 brain.scale_data_colormap(fmin=13, fmid=18, fmax=22, transparent=True,
                           verbose=False)
 
-"""
-To change the time displayed to 80 ms uncomment this line
-"""
+###############################################################################
+# To change the time displayed to 80 ms uncomment this line:
+
 # brain.set_time(0.08)
 
-"""
-uncomment these lines to use the interactive TimeViewer GUI
-"""
+###############################################################################
+# uncomment these lines to use the interactive TimeViewer GUI
+
 # from surfer import TimeViewer
 # viewer = TimeViewer(brain)

--- a/examples/plot_vector_meg_inverse_solution.py
+++ b/examples/plot_vector_meg_inverse_solution.py
@@ -19,7 +19,7 @@ print(__doc__)
 subject_id, surf = 'fsaverage', 'white'
 hemi = 'lh'
 brain = Brain(subject_id, hemi, surf, size=(800, 800), interaction='terrain',
-              cortex='0.5', alpha=0.5, show_toolbar=True)
+              cortex='0.5', alpha=0.5, show_toolbar=True, units='m')
 
 # Read the MNE dSPM inverse solution
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [tool:pytest]
-addopts = --showlocals --durations=10 --doctest-modules -rs --cov --cov-report= --doctest-ignore-import-errors
+addopts = --showlocals --durations=10 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors

--- a/surfer/tests/test_utils.py
+++ b/surfer/tests/test_utils.py
@@ -51,6 +51,11 @@ def test_surface():
         nn = _slow_compute_normals(surface.coords, surface.faces[:10000])
         nn_fast = utils._compute_normals(surface.coords, surface.faces[:10000])
         assert_array_almost_equal(nn, nn_fast)
+        assert 50 < np.linalg.norm(surface.coords, axis=-1).mean() < 100  # mm
+    surface = utils.Surface('fsaverage', 'lh', 'inflated',
+                            subjects_dir=subj_dir, units='m')
+    surface.load_geometry()
+    assert 0.05 < np.linalg.norm(surface.coords, axis=-1).mean() < 0.1  # m
 
 
 def test_huge_cross():

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -6,6 +6,7 @@ import sys
 from tempfile import mkdtemp, mktemp
 import warnings
 
+import pytest
 from nose.tools import assert_equal, assert_in, assert_not_in
 from nose.plugins.skip import SkipTest
 from mayavi import mlab
@@ -240,6 +241,9 @@ def test_label():
     brain.add_label("V2", color="#FF6347", alpha=.6)
     brain.add_label("entorhinal", color=(.2, 1, .5), alpha=.6)
     brain.set_surf('white')
+    brain.show_view(dict(elevation=40, distance=430), distance=430)
+    with pytest.raises(ValueError, match='!='):
+        brain.show_view(dict(elevation=40, distance=430), distance=431)
 
     # remove labels
     brain.remove_labels('V1')

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import logging
 from math import floor
 import os
@@ -22,7 +23,7 @@ from pyface.api import GUI
 
 from . import utils, io
 from .utils import (Surface, verbose, create_color_lut, _get_subjects_dir,
-                    string_types, threshold_filter)
+                    string_types, threshold_filter, _check_units)
 
 
 logger = logging.getLogger('surfer')
@@ -362,6 +363,8 @@ class Brain(object):
     interaction : str
         Can be "trackball" (default) or "terrain", i.e. a turntable-style
         camera.
+    units : str
+        Can be 'm' or 'mm' (default).
 
     Attributes
     ----------
@@ -384,41 +387,13 @@ class Brain(object):
                  cortex="classic", alpha=1.0, size=800, background="black",
                  foreground=None, figure=None, subjects_dir=None,
                  views=['lat'], offset=True, show_toolbar=False,
-                 offscreen=False, interaction='trackball',
-                 config_opts=None, curv=None):
-
-        # Keep backwards compatability
-        if config_opts is not None:
-            msg = ("The `config_opts` dict has been deprecated and will "
-                   "be removed in future versions. You should update your "
-                   "code and pass these options directly to the `Brain` "
-                   "constructor.")
-            warn(msg, DeprecationWarning)
-            cortex = config_opts.get("cortex", cortex)
-            background = config_opts.get("background", background)
-            foreground = config_opts.get("foreground", foreground)
-
-            size = config_opts.get("size", size)
-            width = config_opts.get("width", size)
-            height = config_opts.get("height", size)
-            size = (width, height)
-        # Keep backwards compatability
-        if curv is not None:
-            msg = ("The `curv` keyword has been deprecated and will "
-                   "be removed in future versions. You should update your "
-                   "code and use the `cortex` keyword to specify how the "
-                   "brain surface is rendered. Setting `cortex` to `None` "
-                   "will reproduce the previous behavior when `curv` was "
-                   "set to `False`. To emulate the previous behavior for "
-                   "cases where `curv` was set to `True`, simply omit it.")
-            warn(msg, DeprecationWarning)
-            if not curv:
-                cortex = None
+                 offscreen=False, interaction='trackball', units='mm'):
 
         if not isinstance(interaction, string_types) or \
                 interaction not in ('trackball', 'terrain'):
             raise ValueError('interaction must be "trackball" or "terrain", '
                              'got "%s"' % (interaction,))
+        self._units = _check_units(units)
         col_dict = dict(lh=1, rh=1, both=1, split=2)
         n_col = col_dict[hemi]
         if hemi not in col_dict.keys():
@@ -450,7 +425,8 @@ class Brain(object):
         geo_kwargs, geo_reverse, geo_curv = self._get_geo_params(cortex, alpha)
         for h in geo_hemis:
             # Initialize a Surface object as the geometry
-            geo = Surface(subject_id, h, surf, subjects_dir, offset)
+            geo = Surface(subject_id, h, surf, subjects_dir, offset,
+                          units=self._units)
             # Load in the geometry and (maybe) curvature
             geo.load_geometry()
             if geo_curv:
@@ -1609,8 +1585,8 @@ class Brain(object):
             whether the coords parameter should be interpreted as vertex ids
         map_surface : Freesurfer surf or None
             surface to map coordinates through, or None to use raw coords
-        scale_factor : int
-            controls the size of the foci spheres
+        scale_factor : float
+            Controls the size of the foci spheres (relative to 1cm).
         color : matplotlib color code
             HTML name, RBG tuple, or hex code
         alpha : float in [0, 1]
@@ -1635,7 +1611,8 @@ class Brain(object):
             foci_coords = np.atleast_2d(coords)
         else:
             foci_surf = Surface(self.subject_id, hemi, map_surface,
-                                subjects_dir=self.subjects_dir)
+                                subjects_dir=self.subjects_dir,
+                                units=self._units)
             foci_surf.load_geometry()
             foci_vtxs = utils.find_closest_vertices(foci_surf.coords, coords)
             foci_coords = self.geo[hemi].coords[foci_vtxs]
@@ -1650,6 +1627,8 @@ class Brain(object):
 
         views = self._toggle_render(False)
         fl = []
+        if self._units == 'm':
+            scale_factor = scale_factor / 1000.
         for brain in self._brain_list:
             if brain['hemi'] == hemi:
                 fl.append(brain['brain'].add_foci(foci_coords, scale_factor,
@@ -2996,9 +2975,15 @@ class _Hemisphere(object):
 
         _force_render(self._f)
         if view is not None:
+            view = deepcopy(view)
             view['reset_roll'] = True
             view['figure'] = self._f
-            view['distance'] = distance
+            if 'distance' not in view:
+                view['distance'] = distance
+            elif distance is not None and distance != view['distance']:
+                raise ValueError('view parameters view["distance"] != '
+                                 'distance (%s != %s)' % (view['distance'],
+                                                          distance))
             # DO NOT set focal point, can screw up non-centered brains
             # view['focalpoint'] = (0.0, 0.0, 0.0)
             mlab.view(**view)


### PR DESCRIPTION
This PR:

1. Adds `units` kwarg for `mm` or `m` with tests and modified examples to show it works
2. Fixes bug where `distance` wasn't always respected in `show_view` (because there are two ways to supply it)
3. Removes `Surface.save_geometry` because 1) it's unlikely that it was used in production code by users, 2) it's not used in `PySurfer` at all (not even in tests) and 3) it's really duplicating `nibabel` functionality without adding much.
4. Removes two parameters that have been deprecated for 3 years.