### PR TITLE
FIX save_image() dpi

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2245,12 +2245,12 @@ class Brain(object):
         if mlab.options.backend != 'test':
             mlab.savefig(filename, figure=brain._f)
 
-    def _screenshot_figure(self, mode='rgb', antialiased=False, dpi=100):
+    def _screenshot_figure(self, mode='rgb', antialiased=False):
         """Create a matplolib figure from the current screenshot."""
         # adapted from matplotlib.image.imsave
         from matplotlib.backends.backend_agg import FigureCanvasAgg
         from matplotlib.figure import Figure
-        fig = Figure(dpi=dpi, frameon=False)  # DPI only used for metadata
+        fig = Figure(frameon=False)
         FigureCanvasAgg(fig)
         fig.figimage(self.screenshot(mode, antialiased), resize=True)
         return fig


### PR DESCRIPTION
When setting different DPI in `rcParams` saved images are wrongly scaled (see below). I suspect it's because unlike matplotlib's `imsave`, `PySurfer`  does not use `dpi` when saving the image. This PR fixes this.

![old rh wrong](https://user-images.githubusercontent.com/145771/40877796-8ddec8d0-6654-11e8-9c29-8f96cb944dac.png)