### PR TITLE
ENH: Allow painting all annotation vertices in a single color

### DIFF
--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -165,6 +165,12 @@ def test_annot():
     labels, ctab, names = nib.freesurfer.read_annot(annot_path)
     brain.add_annotation((labels, ctab))
 
+    brain.add_annotation('aparc', color="red", remove_existing=True)
+    surf = brain.annot["surface"]
+    ctab = surf.module_manager.scalar_lut_manager.lut.table
+    for color in ctab:
+        assert color[:3] == (255, 0, 0)
+
     brain.close()
 
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1196,7 +1196,7 @@ class Brain(object):
         self._toggle_render(True, views)
 
     def add_annotation(self, annot, borders=True, alpha=1, hemi=None,
-                       remove_existing=True):
+                       remove_existing=True, color=None):
         """Add an annotation file.
 
         Parameters
@@ -1220,6 +1220,10 @@ class Brain(object):
             for both hemispheres.
         remove_existing : bool
             If True (default), remove old annotations.
+        color : matplotlib-style color code
+            If used, show all annotations in the same (specified) color.
+            Probably useful only when showing annotation borders.
+
         """
         hemis = self._check_hemis(hemi)
 
@@ -1291,6 +1295,12 @@ class Brain(object):
             #  Set the alpha level
             alpha_vec = cmap[:, 3]
             alpha_vec[alpha_vec > 0] = alpha * 255
+
+            # Override the cmap when a single color is used
+            if color is not None:
+                from matplotlib.colors import colorConverter
+                rgb = np.round(np.multiply(colorConverter.to_rgb(color), 255))
+                cmap[:, :3] = rgb.astype(cmap.dtype)
 
             for brain in self._brain_list:
                 if brain['hemi'] == hemi:


### PR DESCRIPTION
A small enhancement that makes it easy to show the borders between annotation labels in a single color. This makes less distracting figures in cases where you want to overlay an annotation on a statistical map and either know what each parcel represents or don't precisely care.

e.g.

```python
from surfer import Brain
b = Brain("fsaverage", "lh", "inflated")
b.add_annotation("aparc", color="dodgerblue")
```
![annot_edges](https://user-images.githubusercontent.com/315810/62878316-d8653980-bcf6-11e9-893e-881f9eeecfc8.png)
