### PR TITLE
BUG: Properly clean up on del

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2298,14 +2298,12 @@ class Brain(object):
         _force_render([])
 
         # should we tear down other variables?
-        if self._v is not None:
+        if getattr(self, '_v', None) is not None:
             self._v.dispose()
             self._v = None
 
     def __del__(self):
-        if hasattr(self, '_v') and self._v is not None:
-            self._v.dispose()
-            self._v = None
+        self.close()
 
     ###########################################################################
     # SAVING OUTPUT


### PR DESCRIPTION
This should fix a bug @drammock hit where memory consumption crept up with multiple `fig` use and `mlab.options.offscreen=True`. Basically we should make sure we close the figures we create, since the offscreen ones can stay open and consume memory.