### PR TITLE
MRG, FIX: Safer exit

### DIFF
--- a/surfer/io.py
+++ b/surfer/io.py
@@ -29,7 +29,7 @@ def read_scalar_data(filepath):
         flat numpy array of scalar data
     """
     try:
-        scalar_data = nib.load(filepath).get_data()
+        scalar_data = np.asanyarray(nib.load(filepath).dataobj)
         scalar_data = np.ravel(scalar_data, order="F")
         return scalar_data
 

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -3,7 +3,6 @@ import os
 import os.path as op
 from os.path import join as pjoin
 import sys
-import warnings
 
 import pytest
 from mayavi import mlab
@@ -16,8 +15,6 @@ from unittest import SkipTest
 from surfer import Brain, io, utils
 from surfer.utils import (requires_fsaverage, requires_imageio, requires_fs,
                           _get_extra)
-
-warnings.simplefilter('always')
 
 subject_id = 'fsaverage'
 std_args = [subject_id, 'lh', 'inflated']
@@ -85,21 +82,12 @@ def test_image(tmpdir):
     brain = Brain(subject_id, 'both', surf=surf, size=100)
     brain.add_overlay(overlay_fname, hemi='lh', min=5, max=20, sign="pos")
     brain.save_imageset(tmp_name, ['med', 'lat'], 'jpg')
-    brain.close()
-    del brain
-
-    brain = Brain(*std_args, size=100)
-    for b in brain.brain_matrix.ravel():
-        assert b._f.scene is not None
     brain.save_image(tmp_name)
     brain.save_image(tmp_name, 'rgba', True)
     brain.screenshot()
-    if os.getenv('TRAVIS', '') != 'true':
-        # for some reason these fail on Travis sometimes
-        brain.save_montage(tmp_name, ['l', 'v', 'm'], orientation='v')
-        brain.save_montage(tmp_name, ['l', 'v', 'm'], orientation='h')
-        brain.save_montage(tmp_name, [['l', 'v'], ['m', 'f']])
-    brain.close()
+    brain.save_montage(tmp_name, ['l', 'v', 'm'], orientation='v')
+    brain.save_montage(tmp_name, ['l', 'v', 'm'], orientation='h')
+    brain.save_montage(tmp_name, [['l', 'v'], ['m', 'f']])
 
 
 @requires_fsaverage()
@@ -108,8 +96,7 @@ def test_brains():
     # testing backend breaks when passing in a figure, so we use 'auto' here
     # (shouldn't affect usability, but it makes testing more annoying)
     _set_backend('auto')
-    with warnings.catch_warnings(record=True):  # traits for mlab.figure()
-        mlab.figure(101)
+    mlab.figure(101)
     surfs = ['inflated', 'white', 'white', 'white', 'white', 'white', 'white']
     hemis = ['lh', 'rh', 'both', 'both', 'rh', 'both', 'both']
     titles = [None, 'Hello', 'Good bye!', 'lut test',
@@ -122,8 +109,7 @@ def test_brains():
                    (0.2, 0.2, 0.2), "black", "0.75"]
     foregrounds = ["black", "white", "0.75", "red",
                    (0.2, 0.2, 0.2), "blue", "black"]
-    with warnings.catch_warnings(record=True):  # traits for mlab.figure()
-        figs = [101, mlab.figure(), None, None, mlab.figure(), None, None]
+    figs = [101, mlab.figure(), None, None, mlab.figure(), None, None]
     subj_dir = utils._get_subjects_dir()
     subj_dirs = [None, subj_dir, subj_dir, subj_dir,
                  subj_dir, subj_dir, subj_dir]
@@ -153,7 +139,6 @@ def test_annot():
     annots = ['aparc', 'aparc.a2005s']
     borders = [True, False, 2]
     alphas = [1, 0.5]
-    gc.collect()
     brain = Brain(*std_args)
     view = get_view(brain)
 
@@ -463,9 +448,8 @@ def test_probabilistic_labels():
     prob_field[ids] = probs
     brain.add_data(prob_field, thresh=1e-5)
 
-    with warnings.catch_warnings(record=True):
-        brain.data["colorbar"].number_of_colors = 10
-        brain.data["colorbar"].number_of_labels = 11
+    brain.data["colorbar"].number_of_colors = 10
+    brain.data["colorbar"].number_of_labels = 11
     brain.close()
 
 

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -91,6 +91,19 @@ def test_image(tmpdir):
 
 
 @requires_fsaverage()
+def test_brain_separate():
+    """Test that Brain does not reuse existing figures by default."""
+    _set_backend('auto')
+    brain = Brain(*std_args)
+    assert brain.brain_matrix.size == 1
+    brain_2 = Brain(*std_args)
+    assert brain_2.brain_matrix.size == 1
+    assert brain._figures[0][0] is not brain_2._figures[0][0]
+    brain_3 = Brain(*std_args, figure=brain._figures[0][0])
+    assert brain._figures[0][0] is brain_3._figures[0][0]
+
+
+@requires_fsaverage()
 def test_brains():
     """Test plotting of Brain with different arguments."""
     # testing backend breaks when passing in a figure, so we use 'auto' here

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import os.path as op
 from os.path import join as pjoin
@@ -85,6 +86,7 @@ def test_image(tmpdir):
     brain.add_overlay(overlay_fname, hemi='lh', min=5, max=20, sign="pos")
     brain.save_imageset(tmp_name, ['med', 'lat'], 'jpg')
     brain.close()
+    del brain
 
     brain = Brain(*std_args, size=100)
     for b in brain.brain_matrix.ravel():
@@ -151,6 +153,7 @@ def test_annot():
     annots = ['aparc', 'aparc.a2005s']
     borders = [True, False, 2]
     alphas = [1, 0.5]
+    gc.collect()
     brain = Brain(*std_args)
     view = get_view(brain)
 

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -87,6 +87,8 @@ def test_image(tmpdir):
     brain.close()
 
     brain = Brain(*std_args, size=100)
+    for b in brain.brain_matrix.ravel():
+        assert b._f.scene is not None
     brain.save_image(tmp_name)
     brain.save_image(tmp_name, 'rgba', True)
     brain.screenshot()

--- a/surfer/tests/test_viz.py
+++ b/surfer/tests/test_viz.py
@@ -1,4 +1,3 @@
-import gc
 import os
 import os.path as op
 from os.path import join as pjoin
@@ -88,6 +87,7 @@ def test_image(tmpdir):
     brain.save_montage(tmp_name, ['l', 'v', 'm'], orientation='v')
     brain.save_montage(tmp_name, ['l', 'v', 'm'], orientation='h')
     brain.save_montage(tmp_name, [['l', 'v'], ['m', 'f']])
+    brain.close()
 
 
 @requires_fsaverage()

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2290,20 +2290,30 @@ class Brain(object):
 
     def close(self):
         """Close all figures and cleanup data structure."""
+
+    def _close(self, force_render=True):
         for ri, ff in enumerate(self._figures):
             for ci, f in enumerate(ff):
                 if f is not None:
-                    mlab.close(f)
+                    try:
+                        mlab.close(f)
+                    except Exception:
+                        pass
                     self._figures[ri][ci] = None
-        _force_render([])
+
+        if force_render:
+            _force_render([])
 
         # should we tear down other variables?
         if getattr(self, '_v', None) is not None:
-            self._v.dispose()
+            try:
+                self._v.dispose()
+            except Exception:
+                pass
             self._v = None
 
     def __del__(self):
-        self.close()
+        self._close(force_render=False)
 
     ###########################################################################
     # SAVING OUTPUT

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -217,8 +217,8 @@ def _make_viewer(figure, n_row, n_col, title, scene_size, offscreen,
             # Triage: don't make TraitsUI if we don't have to
             if n_row == 1 and n_col == 1:
                 with warnings.catch_warnings(record=True):  # traits
-                    figure = mlab.figure(title, size=(w, h))
-                mlab.clf(figure)
+                    figure = mlab.figure(size=(w, h))
+                figure.name = title  # should set the figure title
                 figures = [[figure]]
                 _v = None
             else:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import gc
 import logging
 from math import floor
 import os
@@ -2291,9 +2290,6 @@ class Brain(object):
 
     def close(self):
         """Close all figures and cleanup data structure."""
-        self._close()
-
-    def _close(self, force_render=True):
         for ri, ff in enumerate(self._figures):
             for ci, f in enumerate(ff):
                 if f is not None:
@@ -2303,8 +2299,7 @@ class Brain(object):
                         pass
                     self._figures[ri][ci] = None
 
-        if force_render:
-            _force_render([])
+        _force_render([])
 
         # should we tear down other variables?
         if getattr(self, '_v', None) is not None:
@@ -2313,10 +2308,9 @@ class Brain(object):
             except Exception:
                 pass
             self._v = None
-        gc.collect()
 
     def __del__(self):
-        self._close(force_render=False)
+        self.close()
 
     ###########################################################################
     # SAVING OUTPUT

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2290,6 +2290,7 @@ class Brain(object):
 
     def close(self):
         """Close all figures and cleanup data structure."""
+        self._close()
 
     def _close(self, force_render=True):
         for ri, ff in enumerate(self._figures):

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import gc
 import logging
 from math import floor
 import os
@@ -2312,6 +2313,7 @@ class Brain(object):
             except Exception:
                 pass
             self._v = None
+        gc.collect()
 
     def __del__(self):
         self._close(force_render=False)


### PR DESCRIPTION
Under some circumstances #279 could lead to ugly exits like:
```
$ python -u ~/Desktop/brain.py 
Exception ignored in: <function Brain.__del__ at 0x7fd4dc0ac820>
Traceback (most recent call last):
  File "/home/larsoner/python/PySurfer/surfer/viz.py", line 2306, in __del__
  File "/home/larsoner/python/PySurfer/surfer/viz.py", line 2296, in close
  File "/home/larsoner/python/mayavi/mayavi/tools/figure.py", line 185, in close
  File "/home/larsoner/.local/lib/python3.8/site-packages/apptools/scripting/recordable.py", line 45, in _wrapper
  File "/home/larsoner/python/mayavi/mayavi/core/engine.py", line 491, in close_scene
  File "/home/larsoner/python/mayavi/tvtk/pyface/tvtk_scene.py", line 355, in close
  File "/home/larsoner/.local/lib/python3.8/site-packages/traits/trait_notifiers.py", line 400, in __call__
  File "/home/larsoner/.local/lib/python3.8/site-packages/traits/trait_notifiers.py", line 176, in _handle_exception
  File "/home/larsoner/.local/lib/python3.8/site-packages/traits/trait_notifiers.py", line 251, in _log_exception
ModuleNotFoundError: import of logging halted; None in sys.modules


$ python -u ~/Desktop/brain.py 
QWidget::paintEngine: Should no longer be called
QWidget::paintEngine: Should no longer be called
QWidget::paintEngine: Should no longer be called
QWidget::paintEngine: Should no longer be called
Exception ignored in: <function Brain.__del__ at 0x7f4021dc3820>
Traceback (most recent call last):
  File "/home/larsoner/python/PySurfer/surfer/viz.py", line 2309, in __del__
  File "/home/larsoner/python/PySurfer/surfer/viz.py", line 2305, in close
  File "/home/larsoner/.local/lib/python3.8/site-packages/traitsui/ui.py", line 260, in dispose
  File "/home/larsoner/.local/lib/python3.8/site-packages/traitsui/ui.py", line 595, in save_prefs
  File "/home/larsoner/.local/lib/python3.8/site-packages/traitsui/qt4/toolkit.py", line 327, in save_window
ModuleNotFoundError: import of traitsui.qt4 halted; None in sys.modules
```
This PR gets rid of these warnings for me.

@drammock reports that it still fixes the memory usage problems he had before #279