### PR TITLE
Fix rendering of overlay on some graphic chipsets.

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -3322,6 +3322,11 @@ class _Hemisphere(object):
                 **kwargs)
             surf.actor.property.backface_culling = False
 
+            # There is a bug on some graphics cards concerning transparant
+            # overlays that is fixed by setting force_opaque.
+            if float(alpha) == 1:
+                surf.actor.actor.force_opaque = True
+
         # apply look up table if given
         if lut is not None:
             l_m = surf.module_manager.scalar_lut_manager


### PR DESCRIPTION
Ok. More digging and potential solutions.

An undocumented workaround for various rendering bugs in some graphics drivers is to hack your local [`site-packages/vtkmodules/qt/__init__.py`](https://github.com/Kitware/VTK/blob/master/Wrapping/Python/vtkmodules/qt/__init__.py#L33-L37) file and make this change:

```python
# QVTKRWIBase, base class for QVTKRenderWindowInteractor,
# can be altered by the user to "QGLWidget" in case
# of rendering errors (e.g. depth check problems, readGLBuffer
# warnings...)
QVTKRWIBase = "QGLWidget"  # Changed from "QWidget" -> "QGLWidget"
```

Code relying on `vtkmodules`, such as Mayavi and pyvista, will [check the `QVTKRWIBase` variable and try to do the right thing accordingly](https://github.com/enthought/mayavi/blob/master/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py#L61-L66). Unfortunately, for some reason, it decided to do this:

```python
if PyQtImpl == "PyQt5":
    if QVTKRWIBase == "QGLWidget":
        try:
            from PyQt5.QtWidgets import QOpenGLWidget as QGLWidget
        except:
            from PyQt5.QtOpenGL import QGLWidget
```
I don't know where the `QOpenGLWidget`/`QGLWidget` confusion comes from, but in my case, it needs to be `QGLWidget`, otherwise everything crashes. Removing this try/catch construction and just importing `QGLWidget` fixes this at my end.

This gets me up to this point:

![fig2](https://user-images.githubusercontent.com/428273/74261026-719afa00-4cf2-11ea-857c-f787a6ab9a5a.gif)

Depth ordering bugs are fixed! And now I face the a similar rendering bug as @filip-halemba reported in #284. Sadly, turning on backface culling on the overlay surface had no effect for me. However, turning on `force_opaque` did work! See changes in this PR.

![fig3](https://user-images.githubusercontent.com/428273/74261535-5086d900-4cf3-11ea-9b58-5d187334052c.gif)

Perfection at last!

EDIT:

Closes #284