### PR TITLE
MRG, MAINT: Simpler vector params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             command: |
               python -m pip install --user -q --upgrade pip numpy
               python -m pip install --user -q --upgrade --progress-bar off scipy matplotlib vtk pyqt5 pyqt5-sip nibabel sphinx numpydoc pillow imageio imageio-ffmpeg sphinx-gallery
-              python -m pip install --user -q --upgrade mayavi "https://api.github.com/repos/mne-tools/mne-python/zipball/master"
+              python -m pip install --user -q --upgrade mayavi "https://github.com/mne-tools/mne-python/archive/master.zip"
         - save_cache:
             key: pip-cache
             paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
         pip install https://github.com/enthought/mayavi/zipball/master;
       fi;
     - mkdir -p $SUBJECTS_DIR
-    - pip install "https://api.github.com/repos/mne-tools/mne-python/zipball/master";
+    - pip install "https://github.com/mne-tools/mne-python/archive/master.zip"
     - python -c "import mne; mne.datasets.fetch_fsaverage(verbose=True)"
 
 install:

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -3237,7 +3237,6 @@ class _Hemisphere(object):
 
         # Set scaling for the glyphs
         quiver.glyph.glyph.scale_factor = scale_factor
-        quiver.glyph.glyph.scale_factor = scale_factor
         quiver.glyph.glyph.clamping = False
         quiver.glyph.glyph.range = (0., 1.)
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -1101,8 +1101,7 @@ class Brain(object):
                                  'must equal 3, got %s' % (array.shape[1],))
             magnitude = np.linalg.norm(array, axis=1)
             if scale_factor is None:
-                distance = np.sum([array[:, dim, :].ptp(axis=0).max() ** 2
-                                   for dim in range(3)])
+                distance = 4 * np.linalg.norm(array, axis=1).max()
                 if distance == 0:
                     scale_factor = 1
                 else:
@@ -3238,6 +3237,9 @@ class _Hemisphere(object):
 
         # Set scaling for the glyphs
         quiver.glyph.glyph.scale_factor = scale_factor
+        quiver.glyph.glyph.scale_factor = scale_factor
+        quiver.glyph.glyph.clamping = False
+        quiver.glyph.glyph.range = (0., 1.)
 
         # Scale colormap used for the glyphs
         l_m = quiver.parent.vector_lut_manager
@@ -3487,6 +3489,8 @@ class _Hemisphere(object):
 
             # Update changed parameters, and glyph scaling
             q.glyph.glyph.scale_factor = data['scale_factor']
+            q.glyph.glyph.range = (0., 1.)
+            q.glyph.glyph.clamping = False
             l_m.load_lut_from_list(lut / 255.)
             l_m.data_range = data_range
 

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -423,7 +423,7 @@ class Brain(object):
             title = subject_id
         self.subject_id = subject_id
 
-        if not isinstance(views, list):
+        if not isinstance(views, (list, tuple)):
             views = [views]
         n_row = len(views)
 


### PR DESCRIPTION
We can avoid a lot of gymnastics having to do with maximum magnitudes and even scalars by setting the `scale_mode='vector'` in the `quiver3d` call.