### PR TITLE
STY: Dont log info messages by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,11 @@ before_install:
     - pip install vtk
     - pip install mayavi
     - mkdir -p $SUBJECTS_DIR
-    - pip install "https://api.github.com/repos/mne-tools/mne-python/zipball/master"
+    - if [ "${PYTHON_VERSION}" == "3.5" ]; then
+        pip install "mne<0.21";
+      else
+        pip install "https://api.github.com/repos/mne-tools/mne-python/zipball/master";
+      fi;
     - python -c "import mne; mne.datasets.fetch_fsaverage(verbose=True)"
 
 install:

--- a/surfer/io.py
+++ b/surfer/io.py
@@ -229,7 +229,7 @@ def project_volume_data(filepath, hemi, reg_file=None, subject_id=None,
     # Execute the command
     out_file = mktemp(prefix="pysurfer-v2s", suffix='.mgz')
     cmd_list.extend(["--o", out_file])
-    logger.info(" ".join(cmd_list))
+    logger.debug(" ".join(cmd_list))
     p = Popen(cmd_list, stdout=PIPE, stderr=PIPE, env=env)
     stdout, stderr = p.communicate()
     out = p.returncode

--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -608,7 +608,7 @@ def _nearest(vertices, adj_mat):
 
 def _smooth(vertices, adj_mat, smoothing_steps):
     from scipy import sparse
-    logger.info("Updating smoothing matrix, be patient..")
+    logger.debug("Updating smoothing matrix, be patient..")
     e = adj_mat.copy()
     e.data[e.data == 2] = 1
     n_vertices = e.shape[0]
@@ -626,7 +626,7 @@ def _smooth(vertices, adj_mat, smoothing_steps):
 
         smooth_mat = scale_mat * e_use[idx_use, :] * smooth_mat
 
-        logger.info("Smoothing matrix creation, step %d" % (k + 1))
+        logger.debug("Smoothing matrix creation, step %d" % (k + 1))
         if smoothing_steps is None and len(idx_use) >= n_vertices:
             break
 
@@ -690,7 +690,7 @@ def coord_to_label(subject_id, coord, label, hemi='lh', n_steps=30,
     idx = np.where(data.ravel() > 0)[0]
     # Write label
     label_fname = label + '-' + hemi + '.label'
-    logger.info("Saving label : %s" % label_fname)
+    logger.debug("Saving label : %s" % label_fname)
     f = open(label_fname, 'w')
     f.write('#label at %s from subject %s\n' % (coord, subject_id))
     f.write('%d\n' % len(idx))

--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -2977,12 +2977,13 @@ def _scale_mayavi_lut(lut_table, fmin, fmid, fmax, transparent,
 
     trstr = ['(opaque)', '(transparent)']
     if divergent:
-        logger.info(
+        logger.debug(
             "colormap divergent: center=%0.2e, [%0.2e, %0.2e, %0.2e] %s"
             % (center, fmin, fmid, fmax, trstr[transparent]))
     else:
-        logger.info("colormap sequential: [%0.2e, %0.2e, %0.2e] %s"
-                    % (fmin, fmid, fmax, trstr[transparent]))
+        logger.debug(
+            "colormap sequential: [%0.2e, %0.2e, %0.2e] %s"
+            % (fmin, fmid, fmax, trstr[transparent]))
 
     n_colors = lut_table.shape[0]
 


### PR DESCRIPTION
When processing things in a loop I get spammed by a lot of:
```
colormap sequential: [0.00e+00, 9.68e-01, 1.94e+00] (transparent)
colormap sequential: [0.00e+00, 9.68e-01, 1.94e+00] (transparent)
colormap sequential: [0.00e+00, 9.68e-01, 1.94e+00] (transparent)
colormap sequential: [0.00e+00, 9.68e-01, 1.94e+00] (transparent)
```
I don't think this is very useful for users in general, so by default we probably shouldn't log it.