### PR TITLE
added optional argument 'subjects_dir' to project_volume_data

### DIFF
--- a/surfer/io.py
+++ b/surfer/io.py
@@ -136,7 +136,7 @@ def read_stc(filepath):
 def project_volume_data(filepath, hemi, reg_file=None, subject_id=None,
                         projmeth="frac", projsum="avg", projarg=[0, 1, .1],
                         surf="white", smooth_fwhm=3, mask_label=None,
-                        target_subject=None, verbose=None):
+                        target_subject=None, subjects_dir=None, verbose=None):
     """Sample MRI volume onto cortical manifold.
 
     Note: this requires Freesurfer to be installed with correct
@@ -168,6 +168,10 @@ def project_volume_data(filepath, hemi, reg_file=None, subject_id=None,
         Path to label file to constrain projection; otherwise uses cortex
     target_subject : string
         Subject to warp data to in surface space after projection
+    subjects_dir : string | None
+        If not None, this directory will be used as the subjects directory
+        instead of the value set using the SUBJECTS_DIR environment
+        variable.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see surfer.verbose).
     """
@@ -225,6 +229,8 @@ def project_volume_data(filepath, hemi, reg_file=None, subject_id=None,
         cmd_list.extend(["--mask", mask_label])
     if target_subject is not None:
         cmd_list.extend(["--trgsubject", target_subject])
+    if subjects_dir is not None:
+        cmd_list.extend(["--sd", subjects_dir])
 
     # Execute the command
     out_file = mktemp(prefix="pysurfer-v2s", suffix='.mgz')


### PR DESCRIPTION
Dear PySurfers,

I have improved the "project_volume_data" function in surfer.io. It now accepts an additional optional argument "subjects_dir" of type str (default: None), which overrides the SUBJECTS_DIR environment variable in the call to Freesurfer's mri_vol2surf function by specifying its "--sd" argument.

I find this useful especially when, for instance, the Freesurfer code and the neuroimaging data live on different (remote) servers. 

I have updated the documentation of that function by pasting the explanation of the same argument from PySurfer's "Brain" class. So it should be pretty clear what it does.

I hope you will find this useful!

Cheers,
Michael
