### PR TITLE
Set force_opaque when adding annotations to Brain

### DIFF
--- a/surfer/viz.py
+++ b/surfer/viz.py
@@ -3372,6 +3372,10 @@ class _Hemisphere(object):
         l_m = surf.module_manager.scalar_lut_manager
         l_m.lut.table = np.round(cmap).astype(np.uint8)
 
+        # There is a bug on some graphics cards concerning overlays that is
+        # fixed by setting force_opaque.
+        surf.actor.actor.force_opaque = True
+
         # Set the brain attributes
         return dict(surface=surf, name=annot, colormap=cmap, brain=self,
                     array_id=array_id)


### PR DESCRIPTION
Similarly to #286, there is a render bug when adding atlas annotations on some chipsets. The solution is the same: set the `force_opaque=True` flag on the surface actor. Despite its name, this doesn't seem to interfere with setting the `alpha` for the annotation overlay.

Before this PR:
![fig1](https://user-images.githubusercontent.com/428273/140480515-c5c1ea33-f520-4c17-aae2-badcbfb4694b.png)

After this PR:
![fig2](https://user-images.githubusercontent.com/428273/140480519-539b106d-34fd-4d2e-9b4a-d42f344e8ad1.png)

Playing with transparency: `brain.add.annotation('aparc', alpha=0.3)`
![fig3](https://user-images.githubusercontent.com/428273/140480521-7d03b878-511d-4ca1-b88f-df342ab91076.png)
