### PR TITLE
github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you do not have sudo privileges, you can install locally:
     python setup.py install --home
 
 For information about dependencies, please see the [online
-documentation](http://pysurfer.github.com/install.html)
+documentation](http://pysurfer.github.io/install.html)
 
 License
 -------


### PR DESCRIPTION
the link was broken due to github policy change. 
https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/