### PR TITLE
Python 3.10 | `collections` -> `collections.abc`

### DIFF
--- a/surfer/utils.py
+++ b/surfer/utils.py
@@ -1,4 +1,8 @@
-from collections import Sequence
+import platform
+if "3.10" in platform.python_version():
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 from distutils.version import LooseVersion
 import logging
 import warnings


### PR DESCRIPTION
Fixes https://github.com/nipy/PySurfer/issues/316 without breaking backwards compatibility (hopefully).